### PR TITLE
Add task priority levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ A minimal REST API for managing tasks (in-memory, single process). Intentional b
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/tasks` | List all tasks |
-| POST | `/tasks` | Create a task |
+| GET | `/tasks` | List all tasks, optionally filtered by `priority=low|medium|high` |
+| POST | `/tasks` | Create a task (`priority` defaults to `medium`) |
 | GET | `/tasks/:id` | Get a task |
 | PUT | `/tasks/:id` | Update a task |
 | DELETE | `/tasks/:id` | Delete a task |

--- a/app.py
+++ b/app.py
@@ -4,6 +4,8 @@ from flask import Flask, request, jsonify, g
 app = Flask(__name__)
 app.config["DATABASE"] = "tasks.db"
 
+PRIORITY_LEVELS = {"low", "medium", "high"}
+
 
 def get_db():
     if "db" not in g:
@@ -14,7 +16,8 @@ def get_db():
             "id INTEGER PRIMARY KEY AUTOINCREMENT, "
             "title TEXT, "
             "description TEXT NOT NULL DEFAULT '', "
-            "completed INTEGER NOT NULL DEFAULT 0)"
+            "completed INTEGER NOT NULL DEFAULT 0, "
+            "priority TEXT NOT NULL DEFAULT 'medium')"
         )
         g.db.commit()
     return g.db
@@ -33,13 +36,31 @@ def _row(row):
         "title": row["title"],
         "description": row["description"],
         "completed": bool(row["completed"]),
+        "priority": row["priority"],
     }
+
+
+def _validate_priority(priority):
+    if priority not in PRIORITY_LEVELS:
+        return jsonify({"error": "Priority must be one of: low, medium, high"}), 400
+    return None
 
 
 @app.route("/tasks", methods=["GET"])
 def list_tasks():
-    # Returns all tasks with no filtering or pagination (see issues #4, #7)
-    rows = get_db().execute("SELECT * FROM tasks").fetchall()
+    priority = request.args.get("priority")
+
+    if priority is not None:
+        error = _validate_priority(priority)
+        if error:
+            return error
+        rows = get_db().execute(
+            "SELECT * FROM tasks WHERE priority = ?", (priority,)
+        ).fetchall()
+    else:
+        # Returns all tasks with no pagination (see issue #7)
+        rows = get_db().execute("SELECT * FROM tasks").fetchall()
+
     return jsonify([_row(r) for r in rows])
 
 
@@ -54,11 +75,16 @@ def get_task(task_id):
 @app.route("/tasks", methods=["POST"])
 def create_task():
     data = request.get_json(silent=True) or {}
+    priority = data.get("priority", "medium")
+    error = _validate_priority(priority)
+    if error:
+        return error
+
     # Bug: no validation — title can be None or empty (see issue #3)
     db = get_db()
     cur = db.execute(
-        "INSERT INTO tasks (title, description, completed) VALUES (?, ?, 0)",
-        (data.get("title"), data.get("description", "")),
+        "INSERT INTO tasks (title, description, completed, priority) VALUES (?, ?, 0, ?)",
+        (data.get("title"), data.get("description", ""), priority),
     )
     db.commit()
     row = db.execute("SELECT * FROM tasks WHERE id = ?", (cur.lastrowid,)).fetchone()
@@ -72,13 +98,20 @@ def update_task(task_id):
     if not row:
         return jsonify({"error": "Task not found"}), 404
     data = request.get_json(silent=True) or {}
+
+    if "priority" in data:
+        error = _validate_priority(data["priority"])
+        if error:
+            return error
+
     task = _row(row)
     db.execute(
-        "UPDATE tasks SET title = ?, description = ?, completed = ? WHERE id = ?",
+        "UPDATE tasks SET title = ?, description = ?, completed = ?, priority = ? WHERE id = ?",
         (
             data.get("title", task["title"]),
             data.get("description", task["description"]),
             int(data.get("completed", task["completed"])),
+            data.get("priority", task["priority"]),
             task_id,
         ),
     )

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -26,6 +26,19 @@ def test_create_task(client):
     data = r.get_json()
     assert data["title"] == "Buy milk"
     assert data["completed"] is False
+    assert data["priority"] == "medium"
+
+
+def test_create_task_with_priority(client):
+    r = client.post("/tasks", json={"title": "Urgent", "priority": "high"})
+    assert r.status_code == 201
+    assert r.get_json()["priority"] == "high"
+
+
+def test_create_task_with_invalid_priority(client):
+    r = client.post("/tasks", json={"title": "Bad", "priority": "urgent"})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "Priority must be one of: low, medium, high"
 
 
 def test_get_task(client):
@@ -33,6 +46,7 @@ def test_get_task(client):
     r = client.get("/tasks/1")
     assert r.status_code == 200
     assert r.get_json()["id"] == 1
+    assert r.get_json()["priority"] == "medium"
 
 
 def test_get_missing_task(client):
@@ -42,10 +56,18 @@ def test_get_missing_task(client):
 
 def test_update_task(client):
     client.post("/tasks", json={"title": "Original"})
-    r = client.put("/tasks/1", json={"title": "Updated", "completed": True})
+    r = client.put("/tasks/1", json={"title": "Updated", "completed": True, "priority": "high"})
     assert r.status_code == 200
     assert r.get_json()["title"] == "Updated"
     assert r.get_json()["completed"] is True
+    assert r.get_json()["priority"] == "high"
+
+
+def test_update_task_with_invalid_priority(client):
+    client.post("/tasks", json={"title": "Original"})
+    r = client.put("/tasks/1", json={"priority": "urgent"})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "Priority must be one of: low, medium, high"
 
 
 def test_delete_task(client):
@@ -53,6 +75,25 @@ def test_delete_task(client):
     r = client.delete("/tasks/1")
     assert r.status_code == 200
     assert client.get("/tasks/1").status_code == 404
+
+
+def test_list_tasks_can_filter_by_priority(client):
+    client.post("/tasks", json={"title": "Low", "priority": "low"})
+    client.post("/tasks", json={"title": "High", "priority": "high"})
+    client.post("/tasks", json={"title": "Medium"})
+
+    r = client.get("/tasks?priority=high")
+
+    assert r.status_code == 200
+    assert r.get_json() == [
+        {"id": 2, "title": "High", "description": "", "completed": False, "priority": "high"}
+    ]
+
+
+def test_list_tasks_with_invalid_priority_filter(client):
+    r = client.get("/tasks?priority=urgent")
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "Priority must be one of: low, medium, high"
 
 
 def test_toggle_task(client):


### PR DESCRIPTION
## Summary
- add task priority support with low/medium/high validation and a default of medium
- allow updating and filtering tasks by priority and include priority in task responses
- add pytest coverage for priority behavior and configure pytest to resolve the project root

Closes #2