### PR TITLE
Add input validation to POST /tasks

### DIFF
--- a/app.py
+++ b/app.py
@@ -80,11 +80,16 @@ def create_task():
     if error:
         return error
 
-    # Bug: no validation — title can be None or empty (see issue #3)
+    title = data.get("title")
+    if title is None:
+        return jsonify({"error": "title is required"}), 400
+    if not isinstance(title, str) or not title.strip():
+        return jsonify({"error": "title must not be blank"}), 400
+
     db = get_db()
     cur = db.execute(
         "INSERT INTO tasks (title, description, completed, priority) VALUES (?, ?, 0, ?)",
-        (data.get("title"), data.get("description", ""), priority),
+        (title, data.get("description", ""), priority),
     )
     db.commit()
     row = db.execute("SELECT * FROM tasks WHERE id = ?", (cur.lastrowid,)).fetchone()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -103,9 +103,13 @@ def test_toggle_task(client):
     assert r.get_json()["completed"] is True
 
 
-# Known failures that map to open issues
 def test_create_task_without_title_should_fail(client):
-    # Issue #3: no validation — this currently succeeds with title=None
     r = client.post("/tasks", json={})
-    # Should return 400, but currently returns 201 (bug)
-    assert r.status_code == 201  # change to 400 once issue #3 is fixed
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "title is required"
+
+
+def test_create_task_blank_title_should_fail(client):
+    r = client.post("/tasks", json={"title": "   "})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "title must not be blank"


### PR DESCRIPTION
## Summary

- Returns `400 {"error": "title is required"}` when `title` is missing from the request body
- Returns `400 {"error": "title must not be blank"}` when `title` is an empty or whitespace-only string
- Valid requests continue to return `201` as before

## Test plan

- [x] `test_create_task_without_title_should_fail` — updated to assert 400 (was hardcoded 201 as known-failure marker)
- [x] `test_create_task_blank_title_should_fail` — new test for whitespace-only title
- [x] All 9 tests pass (`pytest tests/test_app.py`)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)