### PR TITLE
[codex] Fix toggle endpoint method

### DIFF
--- a/app.py
+++ b/app.py
@@ -136,8 +136,8 @@ def delete_task(task_id):
     return jsonify({"message": "Task deleted"})
 
 
-# Bug: toggle should be PATCH, not GET — causes caching issues (see issue #4)
-@app.route("/tasks/<int:task_id>/toggle", methods=["GET"])
+# Toggle mutates server state, so it must not be exposed as GET.
+@app.route("/tasks/<int:task_id>/toggle", methods=["PATCH"])
 def toggle_task(task_id):
     db = get_db()
     row = db.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -98,9 +98,15 @@ def test_list_tasks_with_invalid_priority_filter(client):
 
 def test_toggle_task(client):
     client.post("/tasks", json={"title": "Toggle me"})
-    r = client.get("/tasks/1/toggle")  # NOTE: uses GET — see issue #4
+    r = client.patch("/tasks/1/toggle")
     assert r.status_code == 200
     assert r.get_json()["completed"] is True
+
+
+def test_toggle_task_get_not_allowed(client):
+    client.post("/tasks", json={"title": "Toggle me"})
+    r = client.get("/tasks/1/toggle")
+    assert r.status_code == 405
 
 
 def test_create_task_without_title_should_fail(client):


### PR DESCRIPTION
## Summary
- change the toggle route from `GET /tasks/:id/toggle` to `PATCH /tasks/:id/toggle`
- update the tests to use `PATCH` for toggling and assert that `GET` now returns `405`

## Why
`GET /tasks/:id/toggle` mutated server state, which violates HTTP semantics for safe requests and risks accidental replays by browsers, caches, or proxies.

## Impact
Clients must call `PATCH /tasks/:id/toggle` to flip a task's `completed` state. Requests using the old `GET` route now receive `405 Method Not Allowed`.

## Validation
- `pytest tests/`

Fixes #4