### PR TITLE
Add GET /tasks/stats endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,6 +64,33 @@ def list_tasks():
     return jsonify([_row(r) for r in rows])
 
 
+@app.route("/tasks/stats", methods=["GET"])
+def get_task_stats():
+    db = get_db()
+    rows = db.execute("SELECT completed, COUNT(*) as cnt FROM tasks GROUP BY completed").fetchall()
+    completed = 0
+    incomplete = 0
+    for row in rows:
+        if row["completed"]:
+            completed = row["cnt"]
+        else:
+            incomplete = row["cnt"]
+
+    priority_rows = db.execute(
+        "SELECT priority, COUNT(*) as cnt FROM tasks GROUP BY priority"
+    ).fetchall()
+    by_priority = {"low": 0, "medium": 0, "high": 0}
+    for row in priority_rows:
+        by_priority[row["priority"]] = row["cnt"]
+
+    return jsonify({
+        "total": completed + incomplete,
+        "completed": completed,
+        "incomplete": incomplete,
+        "by_priority": by_priority,
+    })
+
+
 @app.route("/tasks/<int:task_id>", methods=["GET"])
 def get_task(task_id):
     row = get_db().execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -1,0 +1,69 @@
+# Spec: Add GET /tasks/stats endpoint
+
+## Problem
+
+There is no way to get aggregate information about tasks. Callers must fetch all tasks and compute counts themselves. Issue #15 asks for a `GET /tasks/stats` endpoint that returns total, completed, incomplete counts and a breakdown by priority level.
+
+## Approach
+
+Add a single new route `GET /tasks/stats` in `app.py` that runs two SQL queries against the existing `tasks` table:
+
+1. A `COUNT(*)` grouped by `completed` to get total/completed/incomplete.
+2. A `COUNT(*)` grouped by `priority` to build the `by_priority` map.
+
+All three known priority levels (`low`, `medium`, `high`) are always present in the response, defaulting to `0` if no tasks of that priority exist.
+
+The route is defined before `GET /tasks/<int:task_id>` — though not strictly necessary (Flask won't confuse the literal path `/tasks/stats` with the `<int:…>` converter), placing it first keeps the ordering logical.
+
+## Changes
+
+**`app.py`** — add one new route:
+
+```python
+@app.route("/tasks/stats", methods=["GET"])
+def get_task_stats():
+    db = get_db()
+    rows = db.execute("SELECT completed, COUNT(*) as cnt FROM tasks GROUP BY completed").fetchall()
+    completed = 0
+    incomplete = 0
+    for row in rows:
+        if row["completed"]:
+            completed = row["cnt"]
+        else:
+            incomplete = row["cnt"]
+    total = completed + incomplete
+
+    priority_rows = db.execute(
+        "SELECT priority, COUNT(*) as cnt FROM tasks GROUP BY priority"
+    ).fetchall()
+    by_priority = {"low": 0, "medium": 0, "high": 0}
+    for row in priority_rows:
+        by_priority[row["priority"]] = row["cnt"]
+
+    return jsonify({"total": total, "completed": completed, "incomplete": incomplete, "by_priority": by_priority})
+```
+
+**`tests/test_app.py`** — add two new test functions:
+
+- `test_stats_empty` — calls `GET /tasks/stats` with no tasks; asserts all counts are zero.
+- `test_stats_counts` — creates tasks with varied priorities and completion states; toggles some; asserts each field in the response matches expected values.
+
+No new files, no schema changes, no dependency changes.
+
+## Test Cases
+
+- Empty database returns `{"total": 0, "completed": 0, "incomplete": 0, "by_priority": {"low": 0, "medium": 0, "high": 0}}`.
+- After creating 1 low, 2 medium, 1 high task and completing 2 of them, the response shows `total=4`, `completed=2`, `incomplete=2`, `by_priority={"low":1,"medium":2,"high":1}`.
+- `by_priority` always contains all three keys even when a priority level has no tasks.
+- All tasks completed — create several tasks, toggle all to completed; assert `incomplete=0` and `completed=total`.
+
+## Risks / Open Questions
+
+- **Route ordering**: Flask distinguishes `/tasks/stats` (literal) from `/tasks/<int:task_id>` (integer converter) by type, so order should not matter — but placing the literal route first is safer and clearer.
+- **Future priorities**: If new priority levels are added, `by_priority` will only include the three hardcoded keys unless the code is updated. This is acceptable for now since `PRIORITY_LEVELS` is also a fixed set.
+
+## Out of Scope
+
+- Filtering stats by date range, assignee, or any other dimension.
+- Pagination or streaming for large datasets.
+- Caching the stats result.

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -43,12 +43,13 @@ def get_task_stats():
     return jsonify({"total": total, "completed": completed, "incomplete": incomplete, "by_priority": by_priority})
 ```
 
-**`tests/test_app.py`** — add two new test functions:
+**`tests/test_app.py`** — add three new test functions:
 
 - `test_stats_empty` — calls `GET /tasks/stats` with no tasks; asserts all counts are zero.
 - `test_stats_counts` — creates tasks with varied priorities and completion states; toggles some; asserts each field in the response matches expected values.
+- `test_stats_all_completed` — creates several tasks, marks all of them completed, and asserts `incomplete=0` and `completed=total`.
 
-No new files, no schema changes, no dependency changes.
+No new application/runtime files, no schema changes, no dependency changes.
 
 ## Test Cases
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -119,3 +119,45 @@ def test_create_task_blank_title_should_fail(client):
     r = client.post("/tasks", json={"title": "   "})
     assert r.status_code == 400
     assert r.get_json()["error"] == "title must not be blank"
+
+
+def test_stats_empty(client):
+    r = client.get("/tasks/stats")
+    assert r.status_code == 200
+    assert r.get_json() == {
+        "total": 0,
+        "completed": 0,
+        "incomplete": 0,
+        "by_priority": {"low": 0, "medium": 0, "high": 0},
+    }
+
+
+def test_stats_counts(client):
+    client.post("/tasks", json={"title": "A", "priority": "low"})
+    client.post("/tasks", json={"title": "B", "priority": "medium"})
+    client.post("/tasks", json={"title": "C", "priority": "medium"})
+    client.post("/tasks", json={"title": "D", "priority": "high"})
+    client.patch("/tasks/2/toggle")
+    client.patch("/tasks/4/toggle")
+
+    r = client.get("/tasks/stats")
+    assert r.status_code == 200
+    assert r.get_json() == {
+        "total": 4,
+        "completed": 2,
+        "incomplete": 2,
+        "by_priority": {"low": 1, "medium": 2, "high": 1},
+    }
+
+
+def test_stats_all_completed(client):
+    client.post("/tasks", json={"title": "A", "priority": "low"})
+    client.post("/tasks", json={"title": "B", "priority": "high"})
+    client.patch("/tasks/1/toggle")
+    client.patch("/tasks/2/toggle")
+
+    r = client.get("/tasks/stats")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["incomplete"] == 0
+    assert data["completed"] == data["total"]


### PR DESCRIPTION
## Summary

- Adds `GET /tasks/stats` to `app.py` returning total, completed, incomplete counts and a `by_priority` breakdown (`low`/`medium`/`high` always present, defaulting to 0)
- Uses two GROUP BY SQL queries — no full table scan in Python
- Adds three new tests: empty db, mixed state, all completed

## Test plan

- [ ] `test_stats_empty` — no tasks → all zeros
- [ ] `test_stats_counts` — mixed priorities/completion states → counts match
- [ ] `test_stats_all_completed` — all tasks toggled complete → `incomplete=0`, `completed=total`
- [ ] All existing tests still pass

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)