### PR TITLE
Enforce 200 character task title limit

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,10 @@ app.config["DATABASE"] = "tasks.db"
 
 PRIORITY_LEVELS = {"low", "medium", "high"}
 
+MAX_TITLE_LENGTH = 200
+
+
+
 
 def get_db():
     if "db" not in g:
@@ -51,6 +55,15 @@ def _validate_priority(priority):
     if priority not in PRIORITY_LEVELS:
         return jsonify({"error": "Priority must be one of: low, medium, high"}), 400
     return None
+
+
+def _validate_title_value(title):
+    if not isinstance(title, str) or not title.strip():
+        return jsonify({"error": "title must not be blank"}), 400
+    if len(title) > MAX_TITLE_LENGTH:
+        return jsonify({"error": f"title must not exceed {MAX_TITLE_LENGTH} characters"}), 400
+    return None
+
 
 
 def _due_date_error():
@@ -145,8 +158,9 @@ def create_task():
     title = data.get("title")
     if title is None:
         return jsonify({"error": "title is required"}), 400
-    if not isinstance(title, str) or not title.strip():
-        return jsonify({"error": "title must not be blank"}), 400
+    error = _validate_title_value(title)
+    if error:
+        return error
 
     error, due_date = _parse_due_date(data.get("due_date"))
     if error:
@@ -175,6 +189,11 @@ def update_task(task_id):
 
     if "priority" in data:
         error = _validate_priority(data["priority"])
+        if error:
+            return error
+
+    if "title" in data:
+        error = _validate_title_value(data["title"])
         if error:
             return error
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -162,6 +162,28 @@ def test_create_task_blank_title_should_fail(client):
     assert r.get_json()["error"] == "title must not be blank"
 
 
+def test_create_task_title_too_long(client):
+    title = "a" * 201
+    r = client.post("/tasks", json={"title": title})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "title must not exceed 200 characters"
+
+
+def test_create_task_title_at_max_length(client):
+    title = "a" * 200
+    r = client.post("/tasks", json={"title": title})
+    assert r.status_code == 201
+    assert r.get_json()["title"] == title
+
+
+def test_update_task_title_too_long(client):
+    client.post("/tasks", json={"title": "Original"})
+    new_title = "a" * 201
+    r = client.put("/tasks/1", json={"title": new_title})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "title must not exceed 200 characters"
+
+
 def test_stats_empty(client):
     r = client.get("/tasks/stats")
     assert r.status_code == 200


### PR DESCRIPTION
## Summary
- enforce a maximum task title length of 200 characters on create and update
- return a 400 error with a consistent message when the limit is exceeded
- add tests covering the boundary conditions for task creation and updates

## Testing
- pytest

Fixes #14
