### PR TITLE
Enforce 200 char task title limit

### DIFF
--- a/app.py
+++ b/app.py
@@ -147,6 +147,8 @@ def create_task():
         return jsonify({"error": "title is required"}), 400
     if not isinstance(title, str) or not title.strip():
         return jsonify({"error": "title must not be blank"}), 400
+    if len(title) > 200:
+        return jsonify({"error": "title must not exceed 200 characters"}), 400
 
     error, due_date = _parse_due_date(data.get("due_date"))
     if error:
@@ -177,6 +179,13 @@ def update_task(task_id):
         error = _validate_priority(data["priority"])
         if error:
             return error
+
+    if "title" in data:
+        title_value = data["title"]
+        if not isinstance(title_value, str) or not title_value.strip():
+            return jsonify({"error": "title must not be blank"}), 400
+        if len(title_value) > 200:
+            return jsonify({"error": "title must not exceed 200 characters"}), 400
 
     task = _row(row)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -162,6 +162,29 @@ def test_create_task_blank_title_should_fail(client):
     assert r.get_json()["error"] == "title must not be blank"
 
 
+
+
+def test_create_task_title_too_long(client):
+    long_title = "a" * 201
+    r = client.post("/tasks", json={"title": long_title})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "title must not exceed 200 characters"
+
+
+def test_create_task_title_at_max_length(client):
+    max_title = "a" * 200
+    r = client.post("/tasks", json={"title": max_title})
+    assert r.status_code == 201
+    assert r.get_json()["title"] == max_title
+
+
+def test_update_task_title_too_long(client):
+    client.post("/tasks", json={"title": "Original"})
+    long_title = "a" * 201
+    r = client.put("/tasks/1", json={"title": long_title})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "title must not exceed 200 characters"
+
 def test_stats_empty(client):
     r = client.get("/tasks/stats")
     assert r.status_code == 200


### PR DESCRIPTION
## Summary
- enforce a 200 character maximum title length during task creation and updates
- return HTTP 400 when the limit is exceeded
- add tests covering create and update validations

## Testing
- pytest

Closes #14