### PR TITLE
Add DELETE /tasks/completed to bulk-delete completed tasks

### DIFF
--- a/app.py
+++ b/app.py
@@ -203,6 +203,14 @@ def update_task(task_id):
     return jsonify(_row(row))
 
 
+@app.route("/tasks/completed", methods=["DELETE"])
+def delete_completed_tasks():
+    db = get_db()
+    cur = db.execute("DELETE FROM tasks WHERE completed = 1")
+    db.commit()
+    return jsonify({"deleted": cur.rowcount})
+
+
 @app.route("/tasks/<int:task_id>", methods=["DELETE"])
 def delete_task(task_id):
     db = get_db()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -217,6 +217,33 @@ def test_update_task_with_empty_body_and_json_content_type(client):
     assert r.get_json()["title"] == "Original"
 
 
+def test_delete_completed_tasks(client):
+    client.post("/tasks", json={"title": "Done"})
+    client.post("/tasks", json={"title": "Not done"})
+    client.patch("/tasks/1/toggle")
+
+    r = client.delete("/tasks/completed")
+    assert r.status_code == 200
+    assert r.get_json() == {"deleted": 1}
+
+    remaining = client.get("/tasks").get_json()
+    assert len(remaining) == 1
+    assert remaining[0]["title"] == "Not done"
+
+
+def test_delete_completed_tasks_none_exist(client):
+    client.post("/tasks", json={"title": "Not done"})
+    r = client.delete("/tasks/completed")
+    assert r.status_code == 200
+    assert r.get_json() == {"deleted": 0}
+
+
+def test_delete_completed_tasks_empty_db(client):
+    r = client.delete("/tasks/completed")
+    assert r.status_code == 200
+    assert r.get_json() == {"deleted": 0}
+
+
 def test_stats_all_completed(client):
     client.post("/tasks", json={"title": "A", "priority": "low"})
     client.post("/tasks", json={"title": "B", "priority": "high"})


### PR DESCRIPTION
## Summary

- Adds `DELETE /tasks/completed` endpoint that deletes all completed tasks in one request
- Returns `{ "deleted": <count> }` — 0 if no completed tasks exist
- Incomplete tasks are unaffected

Closes #28

## Test plan

- [ ] `DELETE /tasks/completed` with mixed tasks returns `{"deleted": 1}` and leaves incomplete tasks intact
- [ ] `DELETE /tasks/completed` when no completed tasks returns `{"deleted": 0}`
- [ ] `DELETE /tasks/completed` on empty database returns `{"deleted": 0}`
- [ ] All 30 existing tests continue to pass (`python3 -m pytest tests/ -v`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)