### PR TITLE
Add pagination to GET /tasks

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+import math
 import sqlite3
 from datetime import datetime
 from flask import Flask, request, jsonify, g
@@ -89,19 +90,51 @@ def health_check():
 @app.route("/tasks", methods=["GET"])
 def list_tasks():
     priority = request.args.get("priority")
+    page_str = request.args.get("page", "1")
+    per_page_str = request.args.get("per_page", "20")
+
+    try:
+        page = int(page_str)
+    except (ValueError, TypeError):
+        return jsonify({"error": "page must be a positive integer"}), 400
+    try:
+        per_page = int(per_page_str)
+    except (ValueError, TypeError):
+        return jsonify({"error": "per_page must be a positive integer"}), 400
+
+    if page < 1:
+        return jsonify({"error": "page must be a positive integer"}), 400
+    if per_page < 1:
+        return jsonify({"error": "per_page must be a positive integer"}), 400
 
     if priority is not None:
         error = _validate_priority(priority)
         if error:
             return error
-        rows = get_db().execute(
-            "SELECT * FROM tasks WHERE priority = ?", (priority,)
+        db = get_db()
+        total = db.execute(
+            "SELECT COUNT(*) FROM tasks WHERE priority = ?", (priority,)
+        ).fetchone()[0]
+        rows = db.execute(
+            "SELECT * FROM tasks WHERE priority = ? LIMIT ? OFFSET ?",
+            (priority, per_page, (page - 1) * per_page),
         ).fetchall()
     else:
-        # Returns all tasks with no pagination (see issue #7)
-        rows = get_db().execute("SELECT * FROM tasks").fetchall()
+        db = get_db()
+        total = db.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
+        rows = db.execute(
+            "SELECT * FROM tasks LIMIT ? OFFSET ?",
+            (per_page, (page - 1) * per_page),
+        ).fetchall()
 
-    return jsonify([_row(r) for r in rows])
+    pages = math.ceil(total / per_page) if total > 0 else 0
+    return jsonify({
+        "items": [_row(r) for r in rows],
+        "total": total,
+        "page": page,
+        "per_page": per_page,
+        "pages": pages,
+    })
 
 
 @app.route("/tasks/stats", methods=["GET"])

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -23,7 +23,12 @@ def test_health_check(client):
 def test_list_empty(client):
     r = client.get("/tasks")
     assert r.status_code == 200
-    assert r.get_json() == []
+    data = r.get_json()
+    assert data["items"] == []
+    assert data["total"] == 0
+    assert data["page"] == 1
+    assert data["per_page"] == 20
+    assert data["pages"] == 0
 
 
 def test_create_task(client):
@@ -131,7 +136,8 @@ def test_list_tasks_can_filter_by_priority(client):
     r = client.get("/tasks?priority=high")
 
     assert r.status_code == 200
-    assert r.get_json() == [
+    data = r.get_json()
+    assert data["items"] == [
         {
             "id": 2,
             "title": "High",
@@ -142,6 +148,7 @@ def test_list_tasks_can_filter_by_priority(client):
             "created_at": high["created_at"],
         }
     ]
+    assert data["total"] == 1
     assert low["created_at"]
     assert medium["created_at"]
 
@@ -280,8 +287,8 @@ def test_delete_completed_tasks(client):
     assert r.get_json() == {"deleted": 1}
 
     remaining = client.get("/tasks").get_json()
-    assert len(remaining) == 1
-    assert remaining[0]["title"] == "Not done"
+    assert remaining["total"] == 1
+    assert remaining["items"][0]["title"] == "Not done"
 
 
 def test_delete_completed_tasks_none_exist(client):
@@ -308,3 +315,89 @@ def test_stats_all_completed(client):
     data = r.get_json()
     assert data["incomplete"] == 0
     assert data["completed"] == data["total"]
+
+
+# --- Pagination tests ---
+
+def test_pagination_defaults(client):
+    for i in range(5):
+        client.post("/tasks", json={"title": f"Task {i}"})
+    r = client.get("/tasks")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["total"] == 5
+    assert data["page"] == 1
+    assert data["per_page"] == 20
+    assert data["pages"] == 1
+    assert len(data["items"]) == 5
+
+
+def test_pagination_limits_items(client):
+    for i in range(5):
+        client.post("/tasks", json={"title": f"Task {i}"})
+    r = client.get("/tasks?page=1&per_page=2")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["total"] == 5
+    assert data["page"] == 1
+    assert data["per_page"] == 2
+    assert data["pages"] == 3
+    assert len(data["items"]) == 2
+
+
+def test_pagination_second_page(client):
+    for i in range(5):
+        client.post("/tasks", json={"title": f"Task {i}"})
+    r = client.get("/tasks?page=2&per_page=2")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["page"] == 2
+    assert len(data["items"]) == 2
+
+
+def test_pagination_out_of_range_returns_empty(client):
+    client.post("/tasks", json={"title": "Only task"})
+    r = client.get("/tasks?page=100&per_page=20")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["items"] == []
+    assert data["total"] == 1
+    assert data["page"] == 100
+
+
+def test_pagination_invalid_page_returns_400(client):
+    r = client.get("/tasks?page=abc")
+    assert r.status_code == 400
+    assert "page" in r.get_json()["error"]
+
+
+def test_pagination_invalid_per_page_returns_400(client):
+    r = client.get("/tasks?per_page=abc")
+    assert r.status_code == 400
+    assert "per_page" in r.get_json()["error"]
+
+
+def test_pagination_negative_page_returns_400(client):
+    r = client.get("/tasks?page=-1")
+    assert r.status_code == 400
+    assert "page" in r.get_json()["error"]
+
+
+def test_pagination_zero_per_page_returns_400(client):
+    r = client.get("/tasks?per_page=0")
+    assert r.status_code == 400
+    assert "per_page" in r.get_json()["error"]
+
+
+def test_pagination_with_priority_filter(client):
+    for _ in range(3):
+        client.post("/tasks", json={"title": "high task", "priority": "high"})
+    for _ in range(2):
+        client.post("/tasks", json={"title": "low task", "priority": "low"})
+    r = client.get("/tasks?priority=high&per_page=2")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["total"] == 3
+    assert data["pages"] == 2
+    assert len(data["items"]) == 2
+    assert all(item["priority"] == "high" for item in data["items"])


### PR DESCRIPTION
## Summary

- Accept `?page` and `?per_page` query parameters on `GET /tasks` (defaults: `page=1`, `per_page=20`)
- Return structured response: `{ items, total, page, per_page, pages }`
- Return 400 for non-integer or non-positive values; empty `items` list for out-of-range pages

## Test plan

- [ ] `pytest tests/` passes (44 tests, 9 new pagination-specific tests)
- [ ] `GET /tasks` default response includes `items`, `total`, `page`, `per_page`, `pages`
- [ ] `GET /tasks?page=1&per_page=2` limits results to 2 items
- [ ] `GET /tasks?page=100` returns empty `items` list (not 404)
- [ ] `GET /tasks?page=-1` and `?per_page=0` return 400
- [ ] `GET /tasks?priority=high&per_page=2` combines filter and pagination correctly

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)