### PR TITLE
Add sort and order options to GET /tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A minimal REST API for managing tasks (in-memory, single process). Intentional b
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/tasks` | List all tasks, optionally filtered by `priority=low|medium|high` |
+| GET | `/tasks` | List all tasks, optionally filtered by `priority=low|medium|high` and sorted with `sort=created_at|priority|title` plus `order=asc|desc` |
 | POST | `/tasks` | Create a task (`priority` defaults to `medium`, optional ISO 8601 `due_date`) |
 | GET | `/tasks/:id` | Get a task |
 | PUT | `/tasks/:id` | Update a task |

--- a/app.py
+++ b/app.py
@@ -7,6 +7,15 @@ app = Flask(__name__)
 app.config["DATABASE"] = "tasks.db"
 
 PRIORITY_LEVELS = {"low", "medium", "high"}
+SORT_FIELDS = {"created_at", "priority", "title"}
+SORT_ORDERS = {"asc", "desc"}
+PRIORITY_SORT_SQL = (
+    "CASE priority "
+    "WHEN 'low' THEN 1 "
+    "WHEN 'medium' THEN 2 "
+    "WHEN 'high' THEN 3 "
+    "END"
+)
 
 
 def get_db():
@@ -62,6 +71,27 @@ def _validate_priority(priority):
     return None
 
 
+def _validate_sort(sort):
+    if sort not in SORT_FIELDS:
+        return jsonify({"error": "sort must be one of: created_at, priority, title"}), 400
+    return None
+
+
+def _validate_order(order):
+    if order not in SORT_ORDERS:
+        return jsonify({"error": "order must be one of: asc, desc"}), 400
+    return None
+
+
+def _tasks_order_by(sort, order):
+    direction = order.upper()
+    if sort == "priority":
+        return f"{PRIORITY_SORT_SQL} {direction}, id ASC"
+    if sort == "title":
+        return f"LOWER(title) {direction}, id ASC"
+    return f"created_at {direction}, id {direction}"
+
+
 def _due_date_error():
     return jsonify({"error": "due_date must be an ISO 8601 string"}), 400
 
@@ -92,6 +122,8 @@ def list_tasks():
     priority = request.args.get("priority")
     page_str = request.args.get("page", "1")
     per_page_str = request.args.get("per_page", "20")
+    sort = request.args.get("sort", "created_at")
+    order = request.args.get("order", "asc")
 
     try:
         page = int(page_str)
@@ -107,23 +139,31 @@ def list_tasks():
     if per_page < 1:
         return jsonify({"error": "per_page must be a positive integer"}), 400
 
+    error = _validate_sort(sort)
+    if error:
+        return error
+
+    error = _validate_order(order)
+    if error:
+        return error
+
+    order_by = _tasks_order_by(sort, order)
+    db = get_db()
     if priority is not None:
         error = _validate_priority(priority)
         if error:
             return error
-        db = get_db()
         total = db.execute(
             "SELECT COUNT(*) FROM tasks WHERE priority = ?", (priority,)
         ).fetchone()[0]
         rows = db.execute(
-            "SELECT * FROM tasks WHERE priority = ? LIMIT ? OFFSET ?",
+            f"SELECT * FROM tasks WHERE priority = ? ORDER BY {order_by} LIMIT ? OFFSET ?",
             (priority, per_page, (page - 1) * per_page),
         ).fetchall()
     else:
-        db = get_db()
         total = db.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
         rows = db.execute(
-            "SELECT * FROM tasks LIMIT ? OFFSET ?",
+            f"SELECT * FROM tasks ORDER BY {order_by} LIMIT ? OFFSET ?",
             (per_page, (page - 1) * per_page),
         ).fetchall()
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,5 @@
 import pytest
-from app import app
+from app import app, get_db
 
 
 @pytest.fixture(autouse=True)
@@ -157,6 +157,69 @@ def test_list_tasks_with_invalid_priority_filter(client):
     r = client.get("/tasks?priority=urgent")
     assert r.status_code == 400
     assert r.get_json()["error"] == "Priority must be one of: low, medium, high"
+
+
+def test_list_tasks_default_sort_is_created_at_ascending(client):
+    client.post("/tasks", json={"title": "First"})
+    client.post("/tasks", json={"title": "Second"})
+    client.post("/tasks", json={"title": "Third"})
+
+    r = client.get("/tasks")
+
+    assert r.status_code == 200
+    assert [item["title"] for item in r.get_json()["items"]] == ["First", "Second", "Third"]
+
+
+def test_list_tasks_can_sort_by_priority_desc(client):
+    client.post("/tasks", json={"title": "Low", "priority": "low"})
+    client.post("/tasks", json={"title": "Medium"})
+    client.post("/tasks", json={"title": "High", "priority": "high"})
+
+    r = client.get("/tasks?sort=priority&order=desc")
+
+    assert r.status_code == 200
+    assert [item["priority"] for item in r.get_json()["items"]] == ["high", "medium", "low"]
+
+
+def test_list_tasks_can_sort_by_title_ascending(client):
+    client.post("/tasks", json={"title": "Zulu"})
+    client.post("/tasks", json={"title": "alpha"})
+    client.post("/tasks", json={"title": "Bravo"})
+
+    r = client.get("/tasks?sort=title&order=asc")
+
+    assert r.status_code == 200
+    assert [item["title"] for item in r.get_json()["items"]] == ["alpha", "Bravo", "Zulu"]
+
+
+def test_list_tasks_can_sort_by_created_at_desc(client):
+    client.post("/tasks", json={"title": "Oldest"})
+    client.post("/tasks", json={"title": "Middle"})
+    client.post("/tasks", json={"title": "Newest"})
+
+    with app.app_context():
+        db = get_db()
+        db.execute("UPDATE tasks SET created_at = ? WHERE id = ?", ("2024-01-01T08:00:00", 1))
+        db.execute("UPDATE tasks SET created_at = ? WHERE id = ?", ("2024-01-02T08:00:00", 2))
+        db.execute("UPDATE tasks SET created_at = ? WHERE id = ?", ("2024-01-03T08:00:00", 3))
+        db.commit()
+
+    r = client.get("/tasks?sort=created_at&order=desc")
+
+    assert r.status_code == 200
+    assert [item["title"] for item in r.get_json()["items"]] == ["Newest", "Middle", "Oldest"]
+
+
+def test_list_tasks_rejects_invalid_sort(client):
+    r = client.get("/tasks?sort=due_date")
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "sort must be one of: created_at, priority, title"
+
+
+def test_list_tasks_rejects_invalid_order(client):
+    r = client.get("/tasks?order=up")
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "order must be one of: asc, desc"
 
 
 def test_toggle_task(client):


### PR DESCRIPTION
## Summary
- add validated `sort` and `order` query params to `GET /tasks`
- support sorting by created_at, priority, and title while preserving the default oldest-first listing
- add coverage for valid and invalid sorting requests and document the endpoint options

Closes #31