### PR TITLE
Add GET /tasks/export endpoint (CSV)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,9 @@
+import csv
+import io
 import math
 import sqlite3
 from datetime import datetime
-from flask import Flask, request, jsonify, g
+from flask import Flask, request, jsonify, g, Response
 
 app = Flask(__name__)
 app.config["DATABASE"] = "tasks.db"
@@ -202,6 +204,30 @@ def get_task_stats():
         "incomplete": incomplete,
         "by_priority": by_priority,
     })
+
+
+@app.route("/tasks/export", methods=["GET"])
+def export_tasks():
+    rows = get_db().execute("SELECT * FROM tasks ORDER BY id ASC").fetchall()
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(["id", "title", "description", "completed", "priority", "due_date", "created_at"])
+    for row in rows:
+        writer.writerow([
+            row["id"],
+            row["title"],
+            row["description"],
+            str(bool(row["completed"])).lower(),
+            row["priority"],
+            row["due_date"] if row["due_date"] is not None else "",
+            row["created_at"],
+        ])
+    return Response(
+        buf.getvalue(),
+        status=200,
+        mimetype="text/csv",
+        headers={"Content-Disposition": 'attachment; filename="tasks.csv"'},
+    )
 
 
 @app.route("/tasks/<int:task_id>", methods=["GET"])

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -464,3 +464,78 @@ def test_pagination_with_priority_filter(client):
     assert data["pages"] == 2
     assert len(data["items"]) == 2
     assert all(item["priority"] == "high" for item in data["items"])
+
+
+# --- Export tests ---
+
+def test_export_content_type(client):
+    r = client.get("/tasks/export")
+    assert r.status_code == 200
+    assert r.content_type == "text/csv; charset=utf-8"
+
+
+def test_export_content_disposition(client):
+    r = client.get("/tasks/export")
+    assert r.headers["Content-Disposition"] == 'attachment; filename="tasks.csv"'
+
+
+def test_export_empty_returns_header_only(client):
+    r = client.get("/tasks/export")
+    assert r.status_code == 200
+    lines = r.data.decode().splitlines()
+    assert lines == ["id,title,description,completed,priority,due_date,created_at"]
+
+
+def test_export_includes_all_tasks(client):
+    import csv, io
+    client.post("/tasks", json={"title": "Buy milk", "description": "2% please", "priority": "medium"})
+    client.post("/tasks", json={"title": "Urgent", "priority": "high"})
+    r = client.get("/tasks/export")
+    assert r.status_code == 200
+    reader = csv.DictReader(io.StringIO(r.data.decode()))
+    rows = list(reader)
+    assert len(rows) == 2
+    assert rows[0]["title"] == "Buy milk"
+    assert rows[0]["description"] == "2% please"
+    assert rows[0]["completed"] == "false"
+    assert rows[0]["priority"] == "medium"
+    assert rows[1]["title"] == "Urgent"
+    assert rows[1]["priority"] == "high"
+
+
+def test_export_completed_field(client):
+    import csv, io
+    client.post("/tasks", json={"title": "Done task"})
+    client.patch("/tasks/1/toggle")
+    r = client.get("/tasks/export")
+    reader = csv.DictReader(io.StringIO(r.data.decode()))
+    rows = list(reader)
+    assert rows[0]["completed"] == "true"
+
+
+def test_export_quotes_commas_and_newlines(client):
+    import csv, io
+    client.post("/tasks", json={"title": "A, B", "description": "line1\nline2"})
+    r = client.get("/tasks/export")
+    reader = csv.DictReader(io.StringIO(r.data.decode()))
+    rows = list(reader)
+    assert rows[0]["title"] == "A, B"
+    assert rows[0]["description"] == "line1\nline2"
+
+
+def test_export_due_date_field(client):
+    import csv, io
+    client.post("/tasks", json={"title": "Pay bills", "due_date": "2024-05-01"})
+    r = client.get("/tasks/export")
+    reader = csv.DictReader(io.StringIO(r.data.decode()))
+    rows = list(reader)
+    assert rows[0]["due_date"] == "2024-05-01"
+
+
+def test_export_null_due_date_is_empty_string(client):
+    import csv, io
+    client.post("/tasks", json={"title": "No date"})
+    r = client.get("/tasks/export")
+    reader = csv.DictReader(io.StringIO(r.data.decode()))
+    rows = list(reader)
+    assert rows[0]["due_date"] == ""


### PR DESCRIPTION
## Summary

- Adds `GET /tasks/export` endpoint that returns all tasks as a downloadable CSV file
- Uses Python's `csv` module for RFC 4180-compliant quoting of commas and newlines in field values
- Empty task list returns only the header row

## Test plan

- [x] `GET /tasks/export` returns `Content-Type: text/csv`
- [x] Response includes `Content-Disposition: attachment; filename="tasks.csv"` header
- [x] CSV has a header row matching task field names
- [x] All tasks are included; empty task list returns only the header row
- [x] Commas and newlines in field values are quoted per RFC 4180
- [x] `pytest tests/` passes (58 tests, all green)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)