### PR TITLE
feat: add optional notes field to tasks (#34)

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,11 +31,14 @@ def get_db():
             "completed INTEGER NOT NULL DEFAULT 0, "
             "priority TEXT NOT NULL DEFAULT 'medium', "
             "due_date TEXT, "
+            "notes TEXT, "
             "created_at TEXT NOT NULL DEFAULT '')"
         )
         columns = {row["name"] for row in db.execute("PRAGMA table_info(tasks)")}
         if "due_date" not in columns:
             db.execute("ALTER TABLE tasks ADD COLUMN due_date TEXT")
+        if "notes" not in columns:
+            db.execute("ALTER TABLE tasks ADD COLUMN notes TEXT")
         if "created_at" not in columns:
             db.execute("ALTER TABLE tasks ADD COLUMN created_at TEXT NOT NULL DEFAULT ''")
             db.execute(
@@ -61,6 +64,7 @@ def _row(row):
         "completed": bool(row["completed"]),
         "priority": row["priority"],
         "due_date": row["due_date"],
+        "notes": row["notes"],
         "created_at": row["created_at"],
     }
 
@@ -235,11 +239,15 @@ def create_task():
     if error:
         return error
 
+    notes = data.get("notes")
+    if notes is not None and not isinstance(notes, str):
+        return jsonify({"error": "notes must be a string or null"}), 400
+
     db = get_db()
     cur = db.execute(
-        "INSERT INTO tasks (title, description, completed, priority, due_date, created_at) "
-        "VALUES (?, ?, 0, ?, ?, strftime('%Y-%m-%dT%H:%M:%S', 'now'))",
-        (title, data.get("description", ""), priority, due_date),
+        "INSERT INTO tasks (title, description, completed, priority, due_date, notes, created_at) "
+        "VALUES (?, ?, 0, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%S', 'now'))",
+        (title, data.get("description", ""), priority, due_date, notes),
     )
     db.commit()
     row = db.execute("SELECT * FROM tasks WHERE id = ?", (cur.lastrowid,)).fetchone()
@@ -278,14 +286,22 @@ def update_task(task_id):
             return error
         due_date = parsed_due_date
 
+    if "notes" in data:
+        notes = data["notes"]
+        if notes is not None and not isinstance(notes, str):
+            return jsonify({"error": "notes must be a string or null"}), 400
+    else:
+        notes = task["notes"]
+
     db.execute(
-        "UPDATE tasks SET title = ?, description = ?, completed = ?, priority = ?, due_date = ? WHERE id = ?",
+        "UPDATE tasks SET title = ?, description = ?, completed = ?, priority = ?, due_date = ?, notes = ? WHERE id = ?",
         (
             data.get("title", task["title"]),
             data.get("description", task["description"]),
             int(data.get("completed", task["completed"])),
             data.get("priority", task["priority"]),
             due_date,
+            notes,
             task_id,
         ),
     )

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -1,70 +1,101 @@
-# Spec: Add GET /tasks/stats endpoint
+# Spec: Add optional notes field to tasks
 
 ## Problem
 
-There is no way to get aggregate information about tasks. Callers must fetch all tasks and compute counts themselves. Issue #15 asks for a `GET /tasks/stats` endpoint that returns total, completed, incomplete counts and a breakdown by priority level.
+Tasks only have a short `description` field. Users need a freeform `notes` field for longer context, links, or checklists that should not pollute the description. Issue #34 asks for an optional `notes` field (string, default `null`) on tasks, surfaced in all CRUD endpoints.
 
 ## Approach
 
-Add a single new route `GET /tasks/stats` in `app.py` that runs two SQL queries against the existing `tasks` table:
-
-1. A `COUNT(*)` grouped by `completed` to get total/completed/incomplete.
-2. A `COUNT(*)` grouped by `priority` to build the `by_priority` map.
-
-All three known priority levels (`low`, `medium`, `high`) are always present in the response, defaulting to `0` if no tasks of that priority exist.
-
-The route is defined before `GET /tasks/<int:task_id>` — though not strictly necessary (Flask won't confuse the literal path `/tasks/stats` with the `<int:…>` converter), placing it first keeps the ordering logical.
+1. Add a `notes TEXT` column to the SQLite `tasks` table (with migration guard using `PRAGMA table_info`).
+2. Include `notes` in the `_row()` helper so every response serializes it.
+3. Accept `notes` in `POST /tasks` and `PUT /tasks/:id`; allow `null` to clear it. Validate that `notes`, when provided, is either a string or `null` (reject any other type with 400).
+4. `GET /tasks` (list) and `GET /tasks/:id` both return `notes`.
+5. No length restriction on `notes` strings.
 
 ## Changes
 
-**`app.py`** — add one new route:
+**`app.py`**
 
-```python
-@app.route("/tasks/stats", methods=["GET"])
-def get_task_stats():
-    db = get_db()
-    rows = db.execute("SELECT completed, COUNT(*) as cnt FROM tasks GROUP BY completed").fetchall()
-    completed = 0
-    incomplete = 0
-    for row in rows:
-        if row["completed"]:
-            completed = row["cnt"]
-        else:
-            incomplete = row["cnt"]
-    total = completed + incomplete
+- `get_db()`: add `notes TEXT` to the `CREATE TABLE` statement and a migration guard:
+  ```python
+  if "notes" not in columns:
+      db.execute("ALTER TABLE tasks ADD COLUMN notes TEXT")
+  ```
 
-    priority_rows = db.execute(
-        "SELECT priority, COUNT(*) as cnt FROM tasks GROUP BY priority"
-    ).fetchall()
-    by_priority = {"low": 0, "medium": 0, "high": 0}
-    for row in priority_rows:
-        by_priority[row["priority"]] = row["cnt"]
+- `_row()`: add `"notes": row["notes"]` to the returned dict.
 
-    return jsonify({"total": total, "completed": completed, "incomplete": incomplete, "by_priority": by_priority})
-```
+- `create_task()`: read and validate `notes`, then pass it to `INSERT`.
+  ```python
+  notes = data.get("notes")
+  if notes is not None and not isinstance(notes, str):
+      return jsonify({"error": "notes must be a string or null"}), 400
 
-**`tests/test_app.py`** — add three new test functions:
+  cur = db.execute(
+      "INSERT INTO tasks (title, description, completed, priority, due_date, notes, created_at) "
+      "VALUES (?, ?, 0, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%S', 'now'))",
+      (title, data.get("description", ""), priority, due_date, notes),
+  )
+  ```
 
-- `test_stats_empty` — calls `GET /tasks/stats` with no tasks; asserts all counts are zero.
-- `test_stats_counts` — creates tasks with varied priorities and completion states; toggles some; asserts each field in the response matches expected values.
-- `test_stats_all_completed` — creates several tasks, marks all of them completed, and asserts `incomplete=0` and `completed=total`.
+- `update_task()`: read and validate `notes`; preserve existing value when key absent; allow `null` to clear.
+  ```python
+  if "notes" in data:
+      notes = data["notes"]
+      if notes is not None and not isinstance(notes, str):
+          return jsonify({"error": "notes must be a string or null"}), 400
+  else:
+      notes = task["notes"]
+  ```
+  Add `notes` to the `UPDATE` SQL and its parameter tuple.
 
-No new application/runtime files, no schema changes, no dependency changes.
+**`tests/test_app.py`**
+
+- Update `test_list_tasks_can_filter_by_priority`: add `"notes": None` to the expected item dict (exact equality check will otherwise fail once `notes` is included in list responses).
+- Add all new test functions listed under Test Cases below.
 
 ## Test Cases
 
-- Empty database returns `{"total": 0, "completed": 0, "incomplete": 0, "by_priority": {"low": 0, "medium": 0, "high": 0}}`.
-- After creating 1 low, 2 medium, 1 high task and completing 2 of them, the response shows `total=4`, `completed=2`, `incomplete=2`, `by_priority={"low":1,"medium":2,"high":1}`.
-- `by_priority` always contains all three keys even when a priority level has no tasks.
-- All tasks completed — create several tasks, toggle all to completed; assert `incomplete=0` and `completed=total`.
+### Create (POST /tasks)
+
+- Creating a task with `notes` set to a string stores and returns the value (status 201).
+- Creating a task without a `notes` key returns `notes: null`.
+- Creating a task with explicit `notes: null` returns `notes: null`.
+- Creating a task with `notes` set to a long multiline string (e.g. 5000+ characters with newlines) stores and returns the full value unchanged — no length restriction.
+- Creating a task with `notes` containing unicode characters (e.g. emoji, CJK) stores and returns them correctly.
+- Creating a task with `notes` set to an integer returns 400 with `"notes must be a string or null"`.
+- Creating a task with `notes` set to a list returns 400 with `"notes must be a string or null"`.
+
+### Read (GET /tasks and GET /tasks/:id)
+
+- `GET /tasks/:id` response includes the `notes` field with its stored value.
+- `GET /tasks/:id` returns `notes: null` when none was set.
+- `GET /tasks` list response includes `notes` on every item.
+- `GET /tasks?priority=high` filtered list includes `notes` in each returned item.
+- Paginated `GET /tasks?page=1&per_page=2` includes `notes` in items.
+
+### Update (PUT /tasks/:id)
+
+- Updating `notes` to a new string value stores and returns the new value.
+- Updating `notes` to `null` clears the field (response has `notes: null`).
+- Sending a PUT body without a `notes` key preserves the existing `notes` value.
+- Updating other fields (e.g. `title`, `priority`) while omitting `notes` leaves `notes` unchanged.
+- Setting `notes` on a task that was created without one (notes was null) correctly stores the new value.
+- Sending `notes` as an integer in a PUT body returns 400 with `"notes must be a string or null"`.
+
+### Toggle (PATCH /tasks/:id/toggle)
+
+- Toggling a task that has `notes` set preserves the `notes` value in the response.
+
+Test file updated: `tests/test_app.py`.
 
 ## Risks / Open Questions
 
-- **Route ordering**: Flask distinguishes `/tasks/stats` (literal) from `/tasks/<int:task_id>` (integer converter) by type, so order should not matter — but placing the literal route first is safer and clearer.
-- **Future priorities**: If new priority levels are added, `by_priority` will only include the three hardcoded keys unless the code is updated. This is acceptable for now since `PRIORITY_LEVELS` is also a fixed set.
+- **Existing test with exact dict comparison**: `test_list_tasks_can_filter_by_priority` asserts full dict equality on list items. Adding `notes` to `_row()` will break it; the fix is to add `"notes": None` to the expected dict. This is the only existing test that does exact dict matching on a task response.
+- **Empty string for notes**: The spec treats `""` as a valid string (distinct from `null`). If the intent is that an empty string should be coerced to `null`, validation logic would need adjustment — not done here since the issue does not mention it.
+- **List vs detail payload size**: The acceptance criteria specifies `notes` in both list and detail responses. If payload size becomes a concern, `notes` could be stripped from list responses in a future change.
 
 ## Out of Scope
 
-- Filtering stats by date range, assignee, or any other dimension.
-- Pagination or streaming for large datasets.
-- Caching the stats result.
+- Length restriction on `notes`.
+- Filtering or sorting by `notes`.
+- Migrating existing `description` data into `notes`.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -145,6 +145,7 @@ def test_list_tasks_can_filter_by_priority(client):
             "completed": False,
             "priority": "high",
             "due_date": None,
+            "notes": None,
             "created_at": high["created_at"],
         }
     ]
@@ -464,3 +465,147 @@ def test_pagination_with_priority_filter(client):
     assert data["pages"] == 2
     assert len(data["items"]) == 2
     assert all(item["priority"] == "high" for item in data["items"])
+
+
+# --- notes field tests ---
+
+def test_create_task_with_notes(client):
+    r = client.post("/tasks", json={"title": "Task", "notes": "some notes here"})
+    assert r.status_code == 201
+    assert r.get_json()["notes"] == "some notes here"
+
+
+def test_create_task_without_notes_defaults_to_null(client):
+    r = client.post("/tasks", json={"title": "Task"})
+    assert r.status_code == 201
+    assert r.get_json()["notes"] is None
+
+
+def test_create_task_with_explicit_null_notes(client):
+    r = client.post("/tasks", json={"title": "Task", "notes": None})
+    assert r.status_code == 201
+    assert r.get_json()["notes"] is None
+
+
+def test_create_task_notes_long_multiline(client):
+    long_notes = "line\n" * 1000 + "end"
+    r = client.post("/tasks", json={"title": "Task", "notes": long_notes})
+    assert r.status_code == 201
+    assert r.get_json()["notes"] == long_notes
+
+
+def test_create_task_notes_unicode(client):
+    notes = "emoji 🎉 CJK 你好 newline\n"
+    r = client.post("/tasks", json={"title": "Task", "notes": notes})
+    assert r.status_code == 201
+    assert r.get_json()["notes"] == notes
+
+
+def test_create_task_notes_integer_returns_400(client):
+    r = client.post("/tasks", json={"title": "Task", "notes": 42})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "notes must be a string or null"
+
+
+def test_create_task_notes_list_returns_400(client):
+    r = client.post("/tasks", json={"title": "Task", "notes": ["a", "b"]})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "notes must be a string or null"
+
+
+def test_get_task_includes_notes(client):
+    client.post("/tasks", json={"title": "Task", "notes": "detail here"})
+    r = client.get("/tasks/1")
+    assert r.status_code == 200
+    assert r.get_json()["notes"] == "detail here"
+
+
+def test_get_task_notes_null_when_not_set(client):
+    client.post("/tasks", json={"title": "Task"})
+    r = client.get("/tasks/1")
+    assert r.status_code == 200
+    assert r.get_json()["notes"] is None
+
+
+def test_list_tasks_includes_notes(client):
+    client.post("/tasks", json={"title": "A", "notes": "n1"})
+    client.post("/tasks", json={"title": "B"})
+    r = client.get("/tasks")
+    assert r.status_code == 200
+    items = r.get_json()["items"]
+    assert items[0]["notes"] == "n1"
+    assert items[1]["notes"] is None
+
+
+def test_list_tasks_filtered_includes_notes(client):
+    client.post("/tasks", json={"title": "H", "priority": "high", "notes": "high note"})
+    client.post("/tasks", json={"title": "L", "priority": "low"})
+    r = client.get("/tasks?priority=high")
+    assert r.status_code == 200
+    items = r.get_json()["items"]
+    assert len(items) == 1
+    assert items[0]["notes"] == "high note"
+
+
+def test_list_tasks_paginated_includes_notes(client):
+    client.post("/tasks", json={"title": "A", "notes": "note A"})
+    client.post("/tasks", json={"title": "B", "notes": "note B"})
+    client.post("/tasks", json={"title": "C"})
+    r = client.get("/tasks?page=1&per_page=2")
+    assert r.status_code == 200
+    items = r.get_json()["items"]
+    assert len(items) == 2
+    assert all("notes" in item for item in items)
+
+
+def test_update_task_notes_to_new_value(client):
+    client.post("/tasks", json={"title": "Task", "notes": "old"})
+    r = client.put("/tasks/1", json={"notes": "new value"})
+    assert r.status_code == 200
+    assert r.get_json()["notes"] == "new value"
+
+
+def test_update_task_notes_to_null_clears_it(client):
+    client.post("/tasks", json={"title": "Task", "notes": "has notes"})
+    r = client.put("/tasks/1", json={"notes": None})
+    assert r.status_code == 200
+    assert r.get_json()["notes"] is None
+
+
+def test_update_task_omitting_notes_preserves_value(client):
+    client.post("/tasks", json={"title": "Task", "notes": "keep me"})
+    r = client.put("/tasks/1", json={"title": "Updated title"})
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["title"] == "Updated title"
+    assert data["notes"] == "keep me"
+
+
+def test_update_other_fields_preserves_notes(client):
+    client.post("/tasks", json={"title": "Task", "notes": "preserved"})
+    r = client.put("/tasks/1", json={"priority": "high", "completed": True})
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["priority"] == "high"
+    assert data["notes"] == "preserved"
+
+
+def test_update_task_set_notes_when_previously_null(client):
+    client.post("/tasks", json={"title": "Task"})
+    r = client.put("/tasks/1", json={"notes": "now has notes"})
+    assert r.status_code == 200
+    assert r.get_json()["notes"] == "now has notes"
+
+
+def test_update_task_notes_integer_returns_400(client):
+    client.post("/tasks", json={"title": "Task"})
+    r = client.put("/tasks/1", json={"notes": 99})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "notes must be a string or null"
+
+
+def test_toggle_preserves_notes(client):
+    client.post("/tasks", json={"title": "Task", "notes": "still here"})
+    r = client.patch("/tasks/1/toggle")
+    assert r.status_code == 200
+    assert r.get_json()["notes"] == "still here"


### PR DESCRIPTION
## Summary

- Adds a `notes TEXT` column to the SQLite `tasks` table (with `ALTER TABLE` migration guard for existing databases)
- `notes` defaults to `null`, is accepted on `POST /tasks` and `PUT /tasks/:id`, and returned in all read responses (`GET /tasks`, `GET /tasks/:id`)
- `PUT /tasks/:id` can set, update, or clear `notes` (pass `null`); omitting the key preserves the existing value
- Type validation rejects non-string, non-null values with HTTP 400 `"notes must be a string or null"`
- No length restriction on the string value

## Test plan

- [ ] `pytest tests/` passes (69 tests, all green)
- [ ] `POST /tasks` with `notes` string → stored and returned in 201
- [ ] `POST /tasks` without `notes` → `notes: null` in response
- [ ] `POST /tasks` with `notes: null` explicitly → `notes: null`
- [ ] `POST /tasks` with `notes` as integer → 400
- [ ] `POST /tasks` with `notes` as list → 400
- [ ] Long multiline / unicode notes stored correctly
- [ ] `GET /tasks/:id` includes `notes`
- [ ] `GET /tasks` list includes `notes` on every item
- [ ] Filtered (`?priority=`) and paginated list include `notes`
- [ ] `PUT /tasks/:id` updates `notes` to new string
- [ ] `PUT /tasks/:id` with `notes: null` clears the field
- [ ] `PUT /tasks/:id` without `notes` key preserves existing value
- [ ] Updating other fields leaves `notes` unchanged
- [ ] `PATCH /tasks/:id/toggle` preserves `notes`

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)