### PR TITLE
feat: add X-Request-ID header to all API responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ A minimal REST API for managing tasks (in-memory, single process). Intentional b
 | DELETE | `/tasks/:id` | Delete a task |
 | GET | `/tasks/:id/toggle` | Toggle completion (buggy — see issue #4) |
 
+### Response headers
+
+Every response includes these headers regardless of status code:
+
+| Header | Example value | Description |
+|--------|---------------|-------------|
+| `X-Request-ID` | `f47ac10b-58cc-4372-a567-0e02b2c3d479` | UUID v4 unique to this request. Use it to correlate client logs with server logs. |
+| `X-Response-Time` | `12ms` | Server processing time in milliseconds, measured from the start of the request to the start of response serialisation. |
+
 ### Running locally
 
 ```bash

--- a/app.py
+++ b/app.py
@@ -3,10 +3,16 @@ import io
 import math
 import sqlite3
 import time
+import uuid
 from datetime import datetime
 from flask import Flask, request, jsonify, g, Response
 
 app = Flask(__name__)
+
+
+@app.before_request
+def _record_request_id():
+    g._request_id = str(uuid.uuid4())
 
 
 @app.before_request
@@ -19,6 +25,7 @@ def _add_response_time_header(response):
     start = g.get("_request_start", time.monotonic())
     elapsed_ms = round((time.monotonic() - start) * 1000)
     response.headers["X-Response-Time"] = f"{elapsed_ms}ms"
+    response.headers["X-Request-ID"] = g.get("_request_id", "")
     return response
 app.config["DATABASE"] = "tasks.db"
 

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -1,56 +1,92 @@
-# Spec: Add response time header to API
+# Spec: Add request ID header to API responses
 
 ## Problem
 
-All API responses are missing an `X-Response-Time` header that indicates how long the server took to process the request. Issue #46 asks for this header to be included on every response, with the value expressed in milliseconds (e.g. `X-Response-Time: 12ms`).
+Issue #51 asks that every API response include an `X-Request-ID` header whose value is a unique UUID (version 4) generated per request. This is useful for distributed tracing and debugging — callers can log or forward the ID to correlate server-side logs with a specific request.
+
+The README currently documents the endpoint table but has no mention of response headers. This PR is also an opportunity to document both `X-Request-ID` and the already-shipped `X-Response-Time` header in one place.
 
 ## Approach
 
-Use Flask's `before_request` / `after_request` hooks to bracket each request:
+Mirror the `X-Response-Time` implementation already in `app.py`:
 
-1. In a `before_request` handler, record `time.monotonic()` in `flask.g` (e.g. `g._request_start`).
-2. In an `after_request` handler, compute elapsed milliseconds and attach the header to the outgoing response object.
+1. In a `before_request` handler, generate a UUID4 string and store it in `flask.g` (e.g. `g._request_id`).
+2. In the existing `_add_response_time_header` `after_request` handler, also attach the `X-Request-ID` header from `g._request_id`.
 
-This approach is transparent to every existing route handler — no route-level changes are needed.
+Using `before_request` / `after_request` hooks keeps all route handlers unchanged.
 
 ## Changes
 
-**`app.py`**
+### `app.py`
 
-- Add `import time` at the top.
-- Add two hook functions after `app = Flask(__name__)`:
+- Add `import uuid` at the top.
+- Add a new `before_request` hook that generates and stores the request ID:
 
 ```python
 @app.before_request
-def _record_start_time():
-    g._request_start = time.monotonic()
-
-@app.after_request
-def _add_response_time_header(response):
-    elapsed_ms = round((time.monotonic() - g._request_start) * 1000)
-    response.headers["X-Response-Time"] = f"{elapsed_ms}ms"
-    return response
+def _record_request_id():
+    g._request_id = str(uuid.uuid4())
 ```
 
-No other files need modification for the core feature.
+- In `_add_response_time_header` (the existing `after_request` hook), add one line to attach the header:
+
+```python
+response.headers["X-Request-ID"] = g.get("_request_id", "")
+```
+
+### `README.md`
+
+Add a **Response headers** subsection under "The app" documenting all standard headers present on every response:
+
+| Header | Example value | Description |
+|--------|---------------|-------------|
+| `X-Request-ID` | `f47ac10b-58cc-4372-a567-0e02b2c3d479` | UUID v4 unique to this request. Use it to correlate client logs with server logs. |
+| `X-Response-Time` | `12ms` | Server processing time in milliseconds, measured from the start of the request to the start of response serialisation. |
 
 ## Test Cases
 
-- Every successful response (2xx) carries an `X-Response-Time` header.
-- The header value matches the pattern `\d+ms` (a non-negative integer followed by "ms").
-- Error responses (4xx) also carry the header (e.g. creating a task with a missing title returns 400 and still has the header).
-- The elapsed time is non-negative (sanity check).
-- Multiple sequential requests each carry their own independent header (header is not cached across requests).
+**Format validation**
+- Header value matches the UUID v4 regex: `[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}` (lowercase hex, correct version bit `4`, correct variant bits `8`, `9`, `a`, or `b`).
+- Header value is parseable by `uuid.UUID(..., version=4)` without raising an exception.
+- Header value is a non-empty string (sanity guard against the fallback path returning `""`).
 
-Test file added/updated: `tests/test_app.py` — new test class or standalone test functions covering the cases above.
+**Coverage across all endpoints and HTTP methods**
+- `GET /health` (200) carries the header.
+- `GET /tasks` (200) carries the header.
+- `POST /tasks` with valid body (201) carries the header.
+- `GET /tasks/<id>` for an existing task (200) carries the header.
+- `PUT /tasks/<id>` update (200) carries the header.
+- `DELETE /tasks/<id>` (200) carries the header.
+- `PATCH /tasks/<id>/toggle` (200) carries the header.
+- `GET /tasks/stats` (200) carries the header.
+- `GET /tasks/export` CSV response (200) carries the header.
+- `DELETE /tasks/completed` (200) carries the header.
+
+**Error and edge-case responses**
+- `POST /tasks` with missing title (400) carries the header.
+- `POST /tasks` with invalid priority (400) carries the header.
+- `GET /tasks/<id>` for a non-existent task (404) carries the header.
+- `GET /tasks/<id>/toggle` using wrong HTTP method `GET` (405 Method Not Allowed) carries the header.
+- `GET /tasks?priority=invalid` (400) carries the header.
+- `GET /tasks?sort=invalid` (400) carries the header.
+- `GET /tasks?page=-1` (400) carries the header.
+
+**Uniqueness and independence**
+- Two sequential requests to the same endpoint produce different `X-Request-ID` values.
+- Ten sequential requests all produce distinct `X-Request-ID` values (no collisions in a small sample).
+- Two requests in the same test produce different IDs (values are not shared across request contexts).
+
+Test file added/updated: `tests/test_app.py` — new test functions grouped under a `# --- X-Request-ID header tests ---` comment block, following the existing style used for `X-Response-Time` tests.
 
 ## Risks / Open Questions
 
-- **Precision**: `time.monotonic()` provides sub-millisecond resolution but `round()` reduces it to integer ms. This is consistent with common practice (e.g. Express's `x-response-time` middleware) and satisfies the issue description of "processing time in milliseconds".
-- **`g._request_start` availability**: If Flask ever invokes `after_request` without a preceding `before_request` (e.g. for certain 500 error flows), `g._request_start` would be missing. Using `g.get("_request_start", time.monotonic())` as a fallback makes the hook safe.
+- **`g._request_id` availability in `after_request`**: If Flask ever invokes `after_request` without a preceding `before_request` (e.g. certain 500 error flows), `g._request_id` would be absent. `g.get("_request_id", "")` provides a safe fallback; the 405 test validates that the hook still fires for Flask's own error responses.
+- **UUID version**: UUID v4 (random) is the standard choice for per-request correlation IDs. Ordered alternatives (v1 timestamp, v7 Unix-time) are out of scope.
+- **405 hook firing**: Flask's built-in 405 handler runs `after_request`, so the hook should fire. Tested explicitly because it is a Flask internal path, not a user route.
+- **README `X-Response-Time` note**: The `X-Response-Time` header has been in production since PR #46 but was never documented. This PR adds it to the README alongside `X-Request-ID` to avoid a second documentation gap.
 
 ## Out of Scope
 
-- Sub-millisecond precision (e.g. microseconds).
-- Per-endpoint timing breakdown.
-- Persisting or logging response times.
+- Accepting a caller-supplied `X-Request-ID` header and echoing it back (correlation via header propagation).
+- Logging or persisting the request ID server-side.
+- Sub-millisecond or structured timing data.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -753,3 +753,148 @@ def test_response_time_header_independent_per_request(client):
     r2 = client.get("/health")
     assert _RT_PATTERN.match(r1.headers.get("X-Response-Time", ""))
     assert _RT_PATTERN.match(r2.headers.get("X-Response-Time", ""))
+
+
+# --- X-Request-ID header tests ---
+
+import uuid as _uuid_mod
+
+_UUID4_PATTERN = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+
+
+def _assert_request_id(response):
+    value = response.headers.get("X-Request-ID", "")
+    assert _UUID4_PATTERN.match(value), f"X-Request-ID {value!r} is not a valid UUID v4"
+    _uuid_mod.UUID(value, version=4)
+    assert value
+
+
+# Format validation
+
+def test_request_id_is_valid_uuid4(client):
+    r = client.get("/health")
+    _assert_request_id(r)
+
+
+def test_request_id_parseable_by_uuid_module(client):
+    r = client.get("/health")
+    value = r.headers.get("X-Request-ID", "")
+    parsed = _uuid_mod.UUID(value, version=4)
+    assert parsed.version == 4
+
+
+def test_request_id_is_non_empty(client):
+    r = client.get("/health")
+    assert r.headers.get("X-Request-ID", "") != ""
+
+
+# Coverage across all endpoints and HTTP methods
+
+def test_request_id_on_get_health(client):
+    _assert_request_id(client.get("/health"))
+
+
+def test_request_id_on_get_tasks(client):
+    _assert_request_id(client.get("/tasks"))
+
+
+def test_request_id_on_post_tasks(client):
+    _assert_request_id(client.post("/tasks", json={"title": "ID test"}))
+
+
+def test_request_id_on_get_task(client):
+    client.post("/tasks", json={"title": "ID test"})
+    _assert_request_id(client.get("/tasks/1"))
+
+
+def test_request_id_on_put_task(client):
+    client.post("/tasks", json={"title": "ID test"})
+    _assert_request_id(client.put("/tasks/1", json={"title": "Updated"}))
+
+
+def test_request_id_on_delete_task(client):
+    client.post("/tasks", json={"title": "ID test"})
+    _assert_request_id(client.delete("/tasks/1"))
+
+
+def test_request_id_on_patch_toggle(client):
+    client.post("/tasks", json={"title": "ID test"})
+    _assert_request_id(client.patch("/tasks/1/toggle"))
+
+
+def test_request_id_on_get_stats(client):
+    _assert_request_id(client.get("/tasks/stats"))
+
+
+def test_request_id_on_get_export(client):
+    _assert_request_id(client.get("/tasks/export"))
+
+
+def test_request_id_on_delete_completed(client):
+    _assert_request_id(client.delete("/tasks/completed"))
+
+
+# Error and edge-case responses
+
+def test_request_id_on_400_missing_title(client):
+    r = client.post("/tasks", json={})
+    assert r.status_code == 400
+    _assert_request_id(r)
+
+
+def test_request_id_on_400_invalid_priority(client):
+    r = client.post("/tasks", json={"title": "X", "priority": "urgent"})
+    assert r.status_code == 400
+    _assert_request_id(r)
+
+
+def test_request_id_on_404_task_not_found(client):
+    r = client.get("/tasks/9999")
+    assert r.status_code == 404
+    _assert_request_id(r)
+
+
+def test_request_id_on_405_wrong_method(client):
+    client.post("/tasks", json={"title": "ID test"})
+    r = client.get("/tasks/1/toggle")
+    assert r.status_code == 405
+    _assert_request_id(r)
+
+
+def test_request_id_on_400_invalid_priority_filter(client):
+    r = client.get("/tasks?priority=invalid")
+    assert r.status_code == 400
+    _assert_request_id(r)
+
+
+def test_request_id_on_400_invalid_sort(client):
+    r = client.get("/tasks?sort=invalid")
+    assert r.status_code == 400
+    _assert_request_id(r)
+
+
+def test_request_id_on_400_negative_page(client):
+    r = client.get("/tasks?page=-1")
+    assert r.status_code == 400
+    _assert_request_id(r)
+
+
+# Uniqueness and independence
+
+def test_request_id_unique_across_two_requests(client):
+    id1 = client.get("/health").headers.get("X-Request-ID")
+    id2 = client.get("/health").headers.get("X-Request-ID")
+    assert id1 != id2
+
+
+def test_request_id_unique_across_ten_requests(client):
+    ids = [client.get("/health").headers.get("X-Request-ID") for _ in range(10)]
+    assert len(set(ids)) == 10
+
+
+def test_request_id_independent_between_two_requests(client):
+    r1 = client.get("/tasks")
+    r2 = client.post("/tasks", json={"title": "Another"})
+    assert r1.headers.get("X-Request-ID") != r2.headers.get("X-Request-ID")


### PR DESCRIPTION
## Summary

- Adds a `before_request` hook that generates a UUID v4 per request and stores it in `flask.g._request_id`
- The existing `after_request` hook now also sets `X-Request-ID` on every response (2xx, 4xx, 405, etc.)
- Updates `README.md` with a **Response headers** table documenting both `X-Request-ID` and the previously undocumented `X-Response-Time`

## Test plan

- [ ] Format validation: header matches UUID v4 regex and is parseable by `uuid.UUID(..., version=4)`
- [ ] Header present on all 10 endpoints (`GET /health`, `GET/POST /tasks`, `GET/PUT/DELETE /tasks/<id>`, `PATCH /tasks/<id>/toggle`, `GET /tasks/stats`, `GET /tasks/export`, `DELETE /tasks/completed`)
- [ ] Header present on error responses: 400 (missing title, invalid priority, invalid sort, negative page), 404, 405
- [ ] Uniqueness: two sequential requests differ; 10 sequential requests all distinct

```
pytest tests/ -v   # 109 passed
```

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)