### PR TITLE
chore: refresh stale TEST_PLAN.md test targets for issue #37 sweep

### DIFF
--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -145,10 +145,10 @@ Send a native desktop notification when a headless agent finishes. Also set repo
 
 Start from any directory without `cd`-ing into the repo first.
 
-| Variant | Status |
-|---------|--------|
-| `agentctl start https://github.com/arun-gupta/agentctl-test/issues/44` | ⬜ |
-| `agentctl start https://github.com/arun-gupta/agentctl-test/issues/54 --agent copilot` | ⬜ |
+| Variant | Issue | Status |
+|---------|-------|--------|
+| `agentctl start https://github.com/arun-gupta/agentctl-test/issues/44` | 🟢 [#44](https://github.com/arun-gupta/agentctl-test/issues/44) | ⬜ |
+| `agentctl start https://github.com/arun-gupta/agentctl-test/issues/54 --agent copilot` | 🟢 [#54](https://github.com/arun-gupta/agentctl-test/issues/54) | ⬜ |
 
 ---
 
@@ -170,11 +170,11 @@ Stream `agent.log` for a running or finished headless agent.
 
 Attach to a running headless agent and exit automatically when it finishes.
 
-> **Prerequisite:** run `agentctl start 35 --headless` before testing this — attach requires the agent to still be running.
+> **Prerequisite:** run `agentctl start 55 --headless` before testing this — attach requires the agent to still be running.
 
 | Variant | Issue | Status |
 |---------|-------|--------|
-| `agentctl attach 35` | 🔴 [#35](https://github.com/arun-gupta/agentctl-test/issues/35) | ⬜ |
+| `agentctl attach 55` | 🟢 [#55](https://github.com/arun-gupta/agentctl-test/issues/55) | ⬜ |
 
 ---
 
@@ -210,14 +210,13 @@ Show all linked worktrees and their state. `list` is an alias for `status`.
 
 Remove a worktree after its PR is merged. Issue number is inferred from the current branch when run from inside a linked worktree.
 
+> **Prerequisite for `cleanup <issue>` and `cleanup` (from worktree):** run `agentctl start <issue>`, let the work complete and the PR merge, then run the cleanup variant.
+
 | Variant | Issue | Status |
 |---------|-------|--------|
-| `agentctl cleanup 1` | 🔴 [#1](https://github.com/arun-gupta/agentctl-test/issues/1) | ⬜ |
-| `agentctl cleanup 2` | 🔴 [#2](https://github.com/arun-gupta/agentctl-test/issues/2) | ⬜ |
-| `agentctl cleanup 3` | 🔴 [#3](https://github.com/arun-gupta/agentctl-test/issues/3) | ⬜ |
-| `agentctl cleanup 4` | 🔴 [#4](https://github.com/arun-gupta/agentctl-test/issues/4) | ⬜ |
-| `agentctl cleanup 5` | 🔴 [#5](https://github.com/arun-gupta/agentctl-test/issues/5) | ⬜ |
-| `agentctl cleanup` (cd into worktree first) | any of the above | ⬜ |
+| `agentctl cleanup 56` | 🟢 [#56](https://github.com/arun-gupta/agentctl-test/issues/56) | ⬜ |
+| `agentctl cleanup 57` | 🟢 [#57](https://github.com/arun-gupta/agentctl-test/issues/57) | ⬜ |
+| `agentctl cleanup` (cd into worktree first) | 🟢 [#57](https://github.com/arun-gupta/agentctl-test/issues/57) | ⬜ |
 | `agentctl cleanup --all` | 🟢 [#25](https://github.com/arun-gupta/agentctl-test/issues/25) + 🔴 [#28](https://github.com/arun-gupta/agentctl-test/issues/28) + 🟢 [#29](https://github.com/arun-gupta/agentctl-test/issues/29) | ✅ |
 
 ---
@@ -226,10 +225,12 @@ Remove a worktree after its PR is merged. Issue number is inferred from the curr
 
 Permanently delete a worktree and branches for abandoned or intentionally dropped work. Issue number is inferred from the current branch when run from inside a linked worktree.
 
+> **Prerequisite for `discard` (from worktree):** run `agentctl start 58` to create a worktree, then `cd` into it and run `agentctl discard`.
+
 | Variant | Issue | Status |
 |---------|-------|--------|
 | `agentctl discard 6` | 🟢 [#6](https://github.com/arun-gupta/agentctl-test/issues/6) | ✅ |
-| `agentctl discard` (cd into worktree first) | 🟢 [#26](https://github.com/arun-gupta/agentctl-test/issues/26) or 🟢 [#27](https://github.com/arun-gupta/agentctl-test/issues/27) | ⬜ |
+| `agentctl discard` (cd into worktree first) | 🟢 [#58](https://github.com/arun-gupta/agentctl-test/issues/58) | ⬜ |
 | `agentctl discard --stale` | 🟢 [#26](https://github.com/arun-gupta/agentctl-test/issues/26) or 🟢 [#27](https://github.com/arun-gupta/agentctl-test/issues/27) | ✅ |
 
 ---


### PR DESCRIPTION
## Summary

Closes #37.

Works through the remaining ⬜ rows in TEST_PLAN.md and unblocks them by replacing stale test-target references with fresh open issues. Previously the `attach`, `cleanup <issue>`, and `discard from worktree` rows all pointed at closed issues whose worktrees no longer exist.

- **attach** — was pointing at closed #35 (worktree gone after `cleanup --all`); updated to new open #55 with a matching prerequisite note
- **cleanup `<issue>`** — replaced five closed-issue rows (#1–#5, all cleaned up) with two targeted rows using new open #56 and #57; reduced row count since the command behaviour is identical for any issue number
- **cleanup from worktree** — now explicitly linked to #57 instead of "any of the above"
- **discard from worktree** — replaced the ambiguous "or #26 or #27" (both already used for `discard --stale`) with dedicated open #58
- **start `<url>` table** — added an Issue column (open/closed emoji) for consistency with every other table in the document
- **Prerequisites** — added callout blocks to the cleanup and discard sections explaining the required setup steps

## New issues created to back the updated rows

| Issue | Title | Used for |
|-------|-------|----------|
| [#55](https://github.com/arun-gupta/agentctl-test/issues/55) | Add GET /tasks/count endpoint | `agentctl attach 55` |
| [#56](https://github.com/arun-gupta/agentctl-test/issues/56) | Add task urgency flag | `agentctl cleanup 56` |
| [#57](https://github.com/arun-gupta/agentctl-test/issues/57) | Add task assignee field | `agentctl cleanup 57` + from-worktree |
| [#58](https://github.com/arun-gupta/agentctl-test/issues/58) | Add task color/label field | `agentctl discard` from worktree |

## Test plan

- [ ] Verify TEST_PLAN.md renders correctly on GitHub (tables, emoji, links)
- [ ] Confirm #55, #56, #57, #58 are open on GitHub
- [ ] Confirm all old closed-issue references (#1–#5 in cleanup) are removed
- [ ] Spot-check that `attach`, `cleanup`, and `discard` sections have correct prerequisite notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)