### PR TITLE
Add cursor pagination to task listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A minimal REST API for managing tasks (in-memory, single process). Intentional b
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/tasks` | List all tasks, optionally filtered by `priority=low|medium|high` and sorted with `sort=created_at|priority|title` plus `order=asc|desc` |
+| GET | `/tasks` | List tasks with cursor pagination via `cursor` and `per_page`, optionally filtered by `priority=low|medium|high` and sorted with `sort=created_at|priority|title` plus `order=asc|desc` |
 | POST | `/tasks` | Create a task (`priority` defaults to `medium`, optional ISO 8601 `due_date`) |
 | GET | `/tasks/:id` | Get a task |
 | PUT | `/tasks/:id` | Update a task |
@@ -149,7 +149,7 @@ agentctl start 7 --headless --quiet
 agentctl status --verbose
 ```
 
-Issue #7 — **Add pagination to `GET /tasks`**: Accept `?page=1&per_page=20` query parameters and return a paginated response with `total`, `page`, `per_page`, and `items` fields. `--quiet` suppresses output for CI/batch contexts.
+Issue #7 — **Add pagination to `GET /tasks`**: Accept cursor-based pagination query parameters such as `?per_page=20&cursor=...` and return a paginated response with `total`, `per_page`, `next_cursor`, and `items` fields. `--quiet` suppresses output for CI/batch contexts.
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
+import base64
 import csv
 import io
-import math
+import json
 import sqlite3
 import time
 import uuid
@@ -35,6 +36,7 @@ app.config["DATABASE"] = "tasks.db"
 PRIORITY_LEVELS = {"low", "medium", "high"}
 SORT_FIELDS = {"created_at", "priority", "title"}
 SORT_ORDERS = {"asc", "desc"}
+DEFAULT_PAGE_SIZE = 20
 PRIORITY_SORT_SQL = (
     "CASE priority "
     "WHEN 'low' THEN 1 "
@@ -115,11 +117,99 @@ def _validate_order(order):
 
 def _tasks_order_by(sort, order):
     direction = order.upper()
+    return f"{_tasks_sort_expression(sort)} {direction}, id ASC"
+
+
+def _tasks_sort_expression(sort):
     if sort == "priority":
-        return f"{PRIORITY_SORT_SQL} {direction}, id ASC"
+        return PRIORITY_SORT_SQL
     if sort == "title":
-        return f"LOWER(title) {direction}, id ASC"
-    return f"created_at {direction}, id {direction}"
+        return "LOWER(title)"
+    return "created_at"
+
+
+def _pagination_error(param_name):
+    return jsonify({"error": f"{param_name} must be a positive integer"}), 400
+
+
+def _parse_positive_int(param_name, raw_value):
+    try:
+        value = int(raw_value)
+    except (TypeError, ValueError):
+        return _pagination_error(param_name), None
+    if value < 1:
+        return _pagination_error(param_name), None
+    return None, value
+
+
+def _cursor_error():
+    return jsonify({"error": "cursor must be a valid pagination token"}), 400
+
+
+def _query_cursor_error():
+    return jsonify({"error": "cursor is not valid for the current query"}), 400
+
+
+def _task_sort_value(row, sort):
+    if sort == "priority":
+        return {"low": 1, "medium": 2, "high": 3}[row["priority"]]
+    if sort == "title":
+        return row["title"].lower()
+    return row["created_at"]
+
+
+def _encode_tasks_cursor(sort, order, priority, row):
+    payload = {
+        "sort": sort,
+        "order": order,
+        "priority": priority,
+        "value": _task_sort_value(row, sort),
+        "id": row["id"],
+    }
+    encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(encoded).decode("ascii").rstrip("=")
+
+
+def _decode_tasks_cursor(raw_cursor):
+    if not isinstance(raw_cursor, str) or not raw_cursor:
+        return _cursor_error(), None
+    padded = raw_cursor + "=" * (-len(raw_cursor) % 4)
+    try:
+        decoded = base64.urlsafe_b64decode(padded.encode("ascii")).decode("utf-8")
+        payload = json.loads(decoded)
+    except (ValueError, UnicodeDecodeError):
+        return _cursor_error(), None
+    if not isinstance(payload, dict):
+        return _cursor_error(), None
+
+    sort = payload.get("sort")
+    order = payload.get("order")
+    priority = payload.get("priority")
+    value = payload.get("value")
+    task_id = payload.get("id")
+
+    if sort not in SORT_FIELDS or order not in SORT_ORDERS:
+        return _cursor_error(), None
+    if priority is not None and priority not in PRIORITY_LEVELS:
+        return _cursor_error(), None
+    if not isinstance(task_id, int) or task_id < 1:
+        return _cursor_error(), None
+    if sort == "priority":
+        if not isinstance(value, int) or value not in {1, 2, 3}:
+            return _cursor_error(), None
+    elif not isinstance(value, str):
+        return _cursor_error(), None
+
+    return None, payload
+
+
+def _tasks_cursor_where_clause(sort, order):
+    comparator = ">" if order == "asc" else "<"
+    sort_expression = _tasks_sort_expression(sort)
+    return (
+        f"({sort_expression} {comparator} ? "
+        f"OR ({sort_expression} = ? AND id > ?))"
+    )
 
 
 def _due_date_error():
@@ -150,24 +240,14 @@ def health_check():
 @app.route("/tasks", methods=["GET"])
 def list_tasks():
     priority = request.args.get("priority")
-    page_str = request.args.get("page", "1")
-    per_page_str = request.args.get("per_page", "20")
+    cursor_str = request.args.get("cursor")
+    per_page_str = request.args.get("per_page", str(DEFAULT_PAGE_SIZE))
     sort = request.args.get("sort", "created_at")
     order = request.args.get("order", "asc")
 
-    try:
-        page = int(page_str)
-    except (ValueError, TypeError):
-        return jsonify({"error": "page must be a positive integer"}), 400
-    try:
-        per_page = int(per_page_str)
-    except (ValueError, TypeError):
-        return jsonify({"error": "per_page must be a positive integer"}), 400
-
-    if page < 1:
-        return jsonify({"error": "page must be a positive integer"}), 400
-    if per_page < 1:
-        return jsonify({"error": "per_page must be a positive integer"}), 400
+    error, per_page = _parse_positive_int("per_page", per_page_str)
+    if error:
+        return error
 
     error = _validate_sort(sort)
     if error:
@@ -177,33 +257,58 @@ def list_tasks():
     if error:
         return error
 
-    order_by = _tasks_order_by(sort, order)
-    db = get_db()
     if priority is not None:
         error = _validate_priority(priority)
         if error:
             return error
-        total = db.execute(
-            "SELECT COUNT(*) FROM tasks WHERE priority = ?", (priority,)
-        ).fetchone()[0]
-        rows = db.execute(
-            f"SELECT * FROM tasks WHERE priority = ? ORDER BY {order_by} LIMIT ? OFFSET ?",
-            (priority, per_page, (page - 1) * per_page),
-        ).fetchall()
-    else:
-        total = db.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
-        rows = db.execute(
-            f"SELECT * FROM tasks ORDER BY {order_by} LIMIT ? OFFSET ?",
-            (per_page, (page - 1) * per_page),
-        ).fetchall()
 
-    pages = math.ceil(total / per_page) if total > 0 else 0
+    cursor = None
+    if cursor_str is not None:
+        error, cursor = _decode_tasks_cursor(cursor_str)
+        if error:
+            return error
+        if (
+            cursor["sort"] != sort
+            or cursor["order"] != order
+            or cursor["priority"] != priority
+        ):
+            return _query_cursor_error()
+
+    order_by = _tasks_order_by(sort, order)
+    db = get_db()
+    total_params = []
+    where_clauses = []
+
+    if priority is not None:
+        total_params.append(priority)
+        where_clauses.append("priority = ?")
+
+    query_params = list(total_params)
+    if cursor is not None:
+        where_clauses.append(_tasks_cursor_where_clause(sort, order))
+        query_params.extend([cursor["value"], cursor["value"], cursor["id"]])
+
+    total_where_sql = " WHERE priority = ?" if priority is not None else ""
+    where_sql = f" WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
+    total = db.execute(
+        f"SELECT COUNT(*) FROM tasks{total_where_sql}",
+        tuple(total_params),
+    ).fetchone()[0]
+    rows = db.execute(
+        f"SELECT * FROM tasks{where_sql} ORDER BY {order_by} LIMIT ?",
+        (*query_params, per_page + 1),
+    ).fetchall()
+
+    page_rows = rows[:per_page]
+    next_cursor = None
+    if len(rows) > per_page and page_rows:
+        next_cursor = _encode_tasks_cursor(sort, order, priority, page_rows[-1])
+
     return jsonify({
-        "items": [_row(r) for r in rows],
+        "items": [_row(r) for r in page_rows],
         "total": total,
-        "page": page,
         "per_page": per_page,
-        "pages": pages,
+        "next_cursor": next_cursor,
     })
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -26,9 +26,8 @@ def test_list_empty(client):
     data = r.get_json()
     assert data["items"] == []
     assert data["total"] == 0
-    assert data["page"] == 1
     assert data["per_page"] == 20
-    assert data["pages"] == 0
+    assert data["next_cursor"] is None
 
 
 def test_create_task(client):
@@ -390,49 +389,51 @@ def test_pagination_defaults(client):
     assert r.status_code == 200
     data = r.get_json()
     assert data["total"] == 5
-    assert data["page"] == 1
     assert data["per_page"] == 20
-    assert data["pages"] == 1
     assert len(data["items"]) == 5
+    assert data["next_cursor"] is None
 
 
-def test_pagination_limits_items(client):
+def test_pagination_limits_items_and_returns_cursor(client):
     for i in range(5):
         client.post("/tasks", json={"title": f"Task {i}"})
-    r = client.get("/tasks?page=1&per_page=2")
+    r = client.get("/tasks?per_page=2")
     assert r.status_code == 200
     data = r.get_json()
     assert data["total"] == 5
-    assert data["page"] == 1
     assert data["per_page"] == 2
-    assert data["pages"] == 3
     assert len(data["items"]) == 2
+    assert data["next_cursor"]
 
 
-def test_pagination_second_page(client):
+def test_pagination_cursor_returns_next_page(client):
     for i in range(5):
         client.post("/tasks", json={"title": f"Task {i}"})
-    r = client.get("/tasks?page=2&per_page=2")
+    first_page = client.get("/tasks?per_page=2").get_json()
+
+    r = client.get(f"/tasks?per_page=2&cursor={first_page['next_cursor']}")
+
     assert r.status_code == 200
     data = r.get_json()
-    assert data["page"] == 2
-    assert len(data["items"]) == 2
+    assert [item["title"] for item in data["items"]] == ["Task 2", "Task 3"]
+    assert data["next_cursor"]
 
 
-def test_pagination_out_of_range_returns_empty(client):
-    client.post("/tasks", json={"title": "Only task"})
-    r = client.get("/tasks?page=100&per_page=20")
+def test_pagination_last_page_has_no_next_cursor(client):
+    for i in range(3):
+        client.post("/tasks", json={"title": f"Task {i}"})
+    first_page = client.get("/tasks?per_page=2").get_json()
+    r = client.get(f"/tasks?per_page=2&cursor={first_page['next_cursor']}")
     assert r.status_code == 200
     data = r.get_json()
-    assert data["items"] == []
-    assert data["total"] == 1
-    assert data["page"] == 100
+    assert [item["title"] for item in data["items"]] == ["Task 2"]
+    assert data["next_cursor"] is None
 
 
-def test_pagination_invalid_page_returns_400(client):
-    r = client.get("/tasks?page=abc")
+def test_pagination_invalid_cursor_returns_400(client):
+    r = client.get("/tasks?cursor=not-a-valid-token")
     assert r.status_code == 400
-    assert "page" in r.get_json()["error"]
+    assert "cursor" in r.get_json()["error"]
 
 
 def test_pagination_invalid_per_page_returns_400(client):
@@ -441,10 +442,13 @@ def test_pagination_invalid_per_page_returns_400(client):
     assert "per_page" in r.get_json()["error"]
 
 
-def test_pagination_negative_page_returns_400(client):
-    r = client.get("/tasks?page=-1")
+def test_pagination_cursor_must_match_query(client):
+    for i in range(3):
+        client.post("/tasks", json={"title": f"Task {i}"})
+    first_page = client.get("/tasks?per_page=2&sort=title").get_json()
+    r = client.get(f"/tasks?per_page=2&sort=created_at&cursor={first_page['next_cursor']}")
     assert r.status_code == 400
-    assert "page" in r.get_json()["error"]
+    assert "cursor" in r.get_json()["error"]
 
 
 def test_pagination_zero_per_page_returns_400(client):
@@ -462,9 +466,9 @@ def test_pagination_with_priority_filter(client):
     assert r.status_code == 200
     data = r.get_json()
     assert data["total"] == 3
-    assert data["pages"] == 2
     assert len(data["items"]) == 2
     assert all(item["priority"] == "high" for item in data["items"])
+    assert data["next_cursor"]
 
 
 # --- Export tests ---
@@ -644,7 +648,7 @@ def test_list_tasks_paginated_includes_notes(client):
     client.post("/tasks", json={"title": "A", "notes": "note A"})
     client.post("/tasks", json={"title": "B", "notes": "note B"})
     client.post("/tasks", json={"title": "C"})
-    r = client.get("/tasks?page=1&per_page=2")
+    r = client.get("/tasks?per_page=2")
     assert r.status_code == 200
     items = r.get_json()["items"]
     assert len(items) == 2
@@ -875,8 +879,8 @@ def test_request_id_on_400_invalid_sort(client):
     _assert_request_id(r)
 
 
-def test_request_id_on_400_negative_page(client):
-    r = client.get("/tasks?page=-1")
+def test_request_id_on_400_invalid_cursor(client):
+    r = client.get("/tasks?cursor=not-a-valid-token")
     assert r.status_code == 400
     _assert_request_id(r)
 


### PR DESCRIPTION
## Summary
- replace offset pagination on `GET /tasks` with cursor-based pagination using opaque next-page tokens
- preserve task sorting and priority filters across cursor navigation and document the new contract
- update the test suite for cursor pagination and invalid cursor handling

Closes #54