### PR TITLE
Add cursor pagination to task list endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A minimal REST API for managing tasks (in-memory, single process). Intentional b
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/tasks` | List all tasks, optionally filtered by `priority=low|medium|high` and sorted with `sort=created_at|priority|title` plus `order=asc|desc` |
+| GET | `/tasks` | List all tasks, optionally filtered by `priority=low|medium|high`, sorted with `sort=created_at|priority|title` plus `order=asc|desc`, and paginated with `cursor` + `per_page` |
 | POST | `/tasks` | Create a task (`priority` defaults to `medium`, optional ISO 8601 `due_date`) |
 | GET | `/tasks/:id` | Get a task |
 | PUT | `/tasks/:id` | Update a task |
@@ -149,7 +149,7 @@ agentctl start 7 --headless --quiet
 agentctl status --verbose
 ```
 
-Issue #7 — **Add pagination to `GET /tasks`**: Accept `?page=1&per_page=20` query parameters and return a paginated response with `total`, `page`, `per_page`, and `items` fields. `--quiet` suppresses output for CI/batch contexts.
+Issue #7 — **Add pagination to `GET /tasks`**: Accept `?cursor=<opaque>&per_page=20` query parameters and return a paginated response with `total`, `per_page`, `next_cursor`, and `items` fields. `--quiet` suppresses output for CI/batch contexts.
 
 ---
 

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
+import base64
 import csv
 import io
-import math
+import json
 import sqlite3
 import time
 import uuid
@@ -35,7 +36,8 @@ app.config["DATABASE"] = "tasks.db"
 PRIORITY_LEVELS = {"low", "medium", "high"}
 SORT_FIELDS = {"created_at", "priority", "title"}
 SORT_ORDERS = {"asc", "desc"}
-ALLOWED_LIST_TASKS_PARAMS = frozenset({"priority", "sort", "order", "page", "per_page"})
+ALLOWED_LIST_TASKS_PARAMS = frozenset({"priority", "sort", "order", "cursor", "per_page"})
+DEFAULT_PER_PAGE = 20
 PRIORITY_SORT_SQL = (
     "CASE priority "
     "WHEN 'low' THEN 1 "
@@ -130,6 +132,55 @@ def _tasks_order_by(sort, order):
     return f"created_at {direction}, id {direction}"
 
 
+def _parse_positive_int(value, name):
+    try:
+        parsed = int(value)
+    except (ValueError, TypeError):
+        return (jsonify({"error": f"{name} must be a positive integer"}), 400), None
+    if parsed < 1:
+        return (jsonify({"error": f"{name} must be a positive integer"}), 400), None
+    return None, parsed
+
+
+def _cursor_error():
+    return jsonify({"error": "cursor must be a valid pagination cursor"}), 400
+
+
+def _encode_cursor(offset, priority, sort, order):
+    payload = {
+        "offset": offset,
+        "priority": priority,
+        "sort": sort,
+        "order": order,
+    }
+    encoded = base64.urlsafe_b64encode(json.dumps(payload).encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def _decode_cursor(cursor, priority, sort, order):
+    if not isinstance(cursor, str) or not cursor:
+        return _cursor_error(), None
+
+    padded = cursor + "=" * (-len(cursor) % 4)
+    try:
+        raw_payload = base64.urlsafe_b64decode(padded.encode("ascii"))
+        payload = json.loads(raw_payload.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError, json.JSONDecodeError):
+        return _cursor_error(), None
+
+    if not isinstance(payload, dict):
+        return _cursor_error(), None
+    if payload.get("priority") != priority:
+        return _cursor_error(), None
+    if payload.get("sort") != sort or payload.get("order") != order:
+        return _cursor_error(), None
+
+    offset = payload.get("offset")
+    if not isinstance(offset, int) or offset < 0:
+        return _cursor_error(), None
+    return None, offset
+
+
 def _due_date_error():
     return jsonify({"error": "due_date must be an ISO 8601 string"}), 400
 
@@ -164,24 +215,14 @@ def list_tasks():
     if error:
         return error
     priority = request.args.get("priority")
-    page_str = request.args.get("page", "1")
-    per_page_str = request.args.get("per_page", "20")
+    cursor = request.args.get("cursor")
+    per_page_str = request.args.get("per_page", str(DEFAULT_PER_PAGE))
     sort = request.args.get("sort", "created_at")
     order = request.args.get("order", "asc")
 
-    try:
-        page = int(page_str)
-    except (ValueError, TypeError):
-        return jsonify({"error": "page must be a positive integer"}), 400
-    try:
-        per_page = int(per_page_str)
-    except (ValueError, TypeError):
-        return jsonify({"error": "per_page must be a positive integer"}), 400
-
-    if page < 1:
-        return jsonify({"error": "page must be a positive integer"}), 400
-    if per_page < 1:
-        return jsonify({"error": "per_page must be a positive integer"}), 400
+    error, per_page = _parse_positive_int(per_page_str, "per_page")
+    if error:
+        return error
 
     error = _validate_sort(sort)
     if error:
@@ -191,33 +232,44 @@ def list_tasks():
     if error:
         return error
 
-    order_by = _tasks_order_by(sort, order)
-    db = get_db()
     if priority is not None:
         error = _validate_priority(priority)
         if error:
             return error
+
+    offset = 0
+    if cursor is not None:
+        error, offset = _decode_cursor(cursor, priority, sort, order)
+        if error:
+            return error
+
+    order_by = _tasks_order_by(sort, order)
+    db = get_db()
+    if priority is not None:
         total = db.execute(
             "SELECT COUNT(*) FROM tasks WHERE priority = ?", (priority,)
         ).fetchone()[0]
         rows = db.execute(
             f"SELECT * FROM tasks WHERE priority = ? ORDER BY {order_by} LIMIT ? OFFSET ?",
-            (priority, per_page, (page - 1) * per_page),
+            (priority, per_page, offset),
         ).fetchall()
     else:
         total = db.execute("SELECT COUNT(*) FROM tasks").fetchone()[0]
         rows = db.execute(
             f"SELECT * FROM tasks ORDER BY {order_by} LIMIT ? OFFSET ?",
-            (per_page, (page - 1) * per_page),
+            (per_page, offset),
         ).fetchall()
 
-    pages = math.ceil(total / per_page) if total > 0 else 0
+    next_offset = offset + len(rows)
+    next_cursor = None
+    if next_offset < total:
+        next_cursor = _encode_cursor(next_offset, priority, sort, order)
+
     return jsonify({
         "items": [_row(r) for r in rows],
         "total": total,
-        "page": page,
         "per_page": per_page,
-        "pages": pages,
+        "next_cursor": next_cursor,
     })
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -26,9 +26,8 @@ def test_list_empty(client):
     data = r.get_json()
     assert data["items"] == []
     assert data["total"] == 0
-    assert data["page"] == 1
     assert data["per_page"] == 20
-    assert data["pages"] == 0
+    assert data["next_cursor"] is None
 
 
 def test_create_task(client):
@@ -390,49 +389,49 @@ def test_pagination_defaults(client):
     assert r.status_code == 200
     data = r.get_json()
     assert data["total"] == 5
-    assert data["page"] == 1
     assert data["per_page"] == 20
-    assert data["pages"] == 1
     assert len(data["items"]) == 5
+    assert data["next_cursor"] is None
 
 
 def test_pagination_limits_items(client):
     for i in range(5):
         client.post("/tasks", json={"title": f"Task {i}"})
-    r = client.get("/tasks?page=1&per_page=2")
+    r = client.get("/tasks?per_page=2")
     assert r.status_code == 200
     data = r.get_json()
     assert data["total"] == 5
-    assert data["page"] == 1
     assert data["per_page"] == 2
-    assert data["pages"] == 3
     assert len(data["items"]) == 2
+    assert data["next_cursor"]
 
 
 def test_pagination_second_page(client):
     for i in range(5):
         client.post("/tasks", json={"title": f"Task {i}"})
-    r = client.get("/tasks?page=2&per_page=2")
+    first_page = client.get("/tasks?per_page=2").get_json()
+    r = client.get("/tasks", query_string={"per_page": 2, "cursor": first_page["next_cursor"]})
     assert r.status_code == 200
     data = r.get_json()
-    assert data["page"] == 2
-    assert len(data["items"]) == 2
+    assert [item["title"] for item in data["items"]] == ["Task 2", "Task 3"]
+    assert data["next_cursor"]
 
 
-def test_pagination_out_of_range_returns_empty(client):
-    client.post("/tasks", json={"title": "Only task"})
-    r = client.get("/tasks?page=100&per_page=20")
+def test_pagination_last_page_has_no_next_cursor(client):
+    for i in range(3):
+        client.post("/tasks", json={"title": f"Task {i}"})
+    first_page = client.get("/tasks?per_page=2").get_json()
+    r = client.get("/tasks", query_string={"per_page": 2, "cursor": first_page["next_cursor"]})
     assert r.status_code == 200
     data = r.get_json()
-    assert data["items"] == []
-    assert data["total"] == 1
-    assert data["page"] == 100
+    assert [item["title"] for item in data["items"]] == ["Task 2"]
+    assert data["next_cursor"] is None
 
 
-def test_pagination_invalid_page_returns_400(client):
-    r = client.get("/tasks?page=abc")
+def test_pagination_invalid_cursor_returns_400(client):
+    r = client.get("/tasks?cursor=abc")
     assert r.status_code == 400
-    assert "page" in r.get_json()["error"]
+    assert "cursor" in r.get_json()["error"]
 
 
 def test_pagination_invalid_per_page_returns_400(client):
@@ -441,10 +440,13 @@ def test_pagination_invalid_per_page_returns_400(client):
     assert "per_page" in r.get_json()["error"]
 
 
-def test_pagination_negative_page_returns_400(client):
-    r = client.get("/tasks?page=-1")
+def test_pagination_cursor_rejects_sort_mismatch(client):
+    for i in range(3):
+        client.post("/tasks", json={"title": f"Task {i}"})
+    first_page = client.get("/tasks?per_page=1").get_json()
+    r = client.get("/tasks", query_string={"per_page": 1, "sort": "title", "cursor": first_page["next_cursor"]})
     assert r.status_code == 400
-    assert "page" in r.get_json()["error"]
+    assert "cursor" in r.get_json()["error"]
 
 
 def test_pagination_zero_per_page_returns_400(client):
@@ -462,9 +464,9 @@ def test_pagination_with_priority_filter(client):
     assert r.status_code == 200
     data = r.get_json()
     assert data["total"] == 3
-    assert data["pages"] == 2
     assert len(data["items"]) == 2
     assert all(item["priority"] == "high" for item in data["items"])
+    assert data["next_cursor"]
 
 
 # --- Export tests ---
@@ -644,7 +646,7 @@ def test_list_tasks_paginated_includes_notes(client):
     client.post("/tasks", json={"title": "A", "notes": "note A"})
     client.post("/tasks", json={"title": "B", "notes": "note B"})
     client.post("/tasks", json={"title": "C"})
-    r = client.get("/tasks?page=1&per_page=2")
+    r = client.get("/tasks?per_page=2")
     assert r.status_code == 200
     items = r.get_json()["items"]
     assert len(items) == 2
@@ -875,8 +877,8 @@ def test_request_id_on_400_invalid_sort(client):
     _assert_request_id(r)
 
 
-def test_request_id_on_400_negative_page(client):
-    r = client.get("/tasks?page=-1")
+def test_request_id_on_400_invalid_cursor(client):
+    r = client.get("/tasks?cursor=abc")
     assert r.status_code == 400
     _assert_request_id(r)
 
@@ -980,7 +982,19 @@ def test_list_tasks_rejects_unknown_param_alongside_valid_params(client):
 
 
 def test_list_tasks_all_known_params_accepted(client):
-    r = client.get("/tasks?priority=high&sort=title&order=asc&page=1&per_page=10")
+    client.post("/tasks", json={"title": "A", "priority": "high"})
+    client.post("/tasks", json={"title": "B", "priority": "high"})
+    first_page = client.get("/tasks?priority=high&sort=title&order=asc&per_page=1").get_json()
+    r = client.get(
+        "/tasks",
+        query_string={
+            "priority": "high",
+            "sort": "title",
+            "order": "asc",
+            "cursor": first_page["next_cursor"],
+            "per_page": 10,
+        },
+    )
     assert r.status_code == 200
 
 


### PR DESCRIPTION
## Summary
- switch `GET /tasks` from page-based pagination to opaque cursor pagination
- keep pagination consistent with existing sort and priority filter parameters
- update tests and README for the new `cursor` / `per_page` contract

Fixes #54