### PR TITLE
feat: add input sanitization to task title and description fields

### DIFF
--- a/app.py
+++ b/app.py
@@ -526,8 +526,16 @@ def create_task():
         return jsonify({"error": "title is required"}), 400
     if not isinstance(title, str) or not title.strip():
         return jsonify({"error": "title must not be blank"}), 400
+    title = title.strip()
     if len(title) > 200:
         return jsonify({"error": "title must not exceed 200 characters"}), 400
+
+    description_raw = data.get("description", "")
+    if not isinstance(description_raw, str):
+        return jsonify({"error": "description must be a string"}), 400
+    description = description_raw.strip()
+    if description_raw and not description:
+        return jsonify({"error": "description must not be blank"}), 400
 
     error, due_date = _parse_due_date(data.get("due_date"))
     if error:
@@ -541,7 +549,7 @@ def create_task():
     cur = db.execute(
         "INSERT INTO tasks (title, description, completed, priority, due_date, notes, created_at) "
         "VALUES (?, ?, 0, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%S', 'now'))",
-        (title, data.get("description", ""), priority, due_date, notes),
+        (title, description, priority, due_date, notes),
     )
     db.commit()
     row = db.execute("SELECT * FROM tasks WHERE id = ?", (cur.lastrowid,)).fetchone()
@@ -568,10 +576,21 @@ def update_task(task_id):
         title_value = data["title"]
         if not isinstance(title_value, str) or not title_value.strip():
             return jsonify({"error": "title must not be blank"}), 400
+        title_value = title_value.strip()
         if len(title_value) > 200:
             return jsonify({"error": "title must not exceed 200 characters"}), 400
+        data = {**data, "title": title_value}
 
     task = _row(row)
+
+    if "description" in data:
+        description_raw = data["description"]
+        if not isinstance(description_raw, str):
+            return jsonify({"error": "description must be a string"}), 400
+        description_value = description_raw.strip()
+        if description_raw and not description_value:
+            return jsonify({"error": "description must not be blank"}), 400
+        data = {**data, "description": description_value}
 
     due_date = task["due_date"]
     if "due_date" in data:

--- a/specs/spec.md
+++ b/specs/spec.md
@@ -1,71 +1,163 @@
-# Spec: Add CORS support to API
+# Spec: Add input sanitization to task fields
 
 ## Problem
 
-Issue #47 asks the API to return appropriate CORS headers so browser-based clients can call it successfully. Right now the Flask app returns JSON and CSV responses without any `Access-Control-*` headers, which means browsers will block cross-origin calls and preflighted requests such as `POST`, `PUT`, `PATCH`, and `DELETE` with `application/json`.
+Issue #70 asks for input sanitization on the `title` and `description` fields in both create (`POST /tasks`) and update (`PUT /tasks/:id`). Currently:
+
+- `title` is validated as non-blank (using `title.strip()` for the check), but the *unstripped* value is inserted into the database. A title of `"  Hello  "` is stored verbatim.
+- `description` has no sanitization at all — any string, including all-whitespace strings, is stored verbatim.
+
+The fix must strip leading/trailing whitespace from both fields before storing and reject values that are blank after stripping.
 
 ## Approach
 
-Add CORS behavior centrally at the Flask app level rather than in each route:
+Apply sanitization centrally inside the two route handlers, keeping the same structural pattern already used for validation:
 
-1. Extend the existing global `after_request` hook in `app.py` to attach a small, consistent CORS header set to every response, including error responses and Flask-generated `OPTIONS` responses.
-2. Use permissive defaults suitable for this demo API:
-   - `Access-Control-Allow-Origin: *`
-   - `Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS`
-   - `Access-Control-Allow-Headers: Content-Type`
-3. Rely on Flask's built-in `OPTIONS` handling for routes, verifying via tests that preflight requests receive the expected headers and advertise the supported methods.
-4. Document the new browser access behavior in `README.md`.
+1. **`create_task`** (`POST /tasks`):
+   - Strip `title` before the blank-check and before INSERT. Store the stripped value.
+   - Validate and strip `description` if provided: reject if the original value was non-empty but strips to `""` (all whitespace). If not provided, default to `""` as today.
 
-This keeps the change low-risk and avoids adding per-endpoint branching or a new dependency such as `flask-cors`.
+2. **`update_task`** (`PUT /tasks/:id`):
+   - Strip `title_value` before the blank-check and before UPDATE. Store the stripped value.
+   - Validate and strip `description` if provided: reject if the original value was non-empty but strips to `""`. If omitted, preserve the existing value.
+
+No new helpers, routes, or dependencies are needed.
 
 ## Changes
 
 ### `app.py`
 
-- Update the existing `@app.after_request` hook so it also sets CORS headers on every response.
-- Keep the implementation centralized instead of modifying individual route handlers.
-- Expected header behavior:
+**`create_task` function** (around line 524):
 
 ```python
-response.headers["Access-Control-Allow-Origin"] = "*"
-response.headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, PATCH, DELETE, OPTIONS"
-response.headers["Access-Control-Allow-Headers"] = "Content-Type"
+# After the existing title validation, add:
+title = title.strip()
+
+# Replace the raw description extraction:
+description_raw = data.get("description", "")
+if not isinstance(description_raw, str):
+    return jsonify({"error": "description must be a string"}), 400
+description = description_raw.strip()
+if description_raw and not description:
+    return jsonify({"error": "description must not be blank"}), 400
 ```
 
-- No new routes are expected; preflight support should come from Flask's automatic `OPTIONS` handling on existing endpoints such as:
-  - `OPTIONS /tasks`
-  - `OPTIONS /tasks/<id>`
-  - `OPTIONS /tasks/<id>/toggle`
-  - `OPTIONS /tasks/completed`
+Then pass `description` (stripped) to the INSERT instead of `data.get("description", "")`.
 
-### `README.md`
+**`update_task` function** (around line 567):
 
-- Add a short note documenting that the API supports cross-origin browser access with permissive CORS headers.
-- If helpful, mention the allowed methods and that JSON requests may send `Content-Type`.
+```python
+# After existing title type-check, add:
+title_value = title_value.strip()
+if not title_value:
+    return jsonify({"error": "title must not be blank"}), 400
+
+# New description sanitization block (when "description" is in data):
+if "description" in data:
+    description_raw = data["description"]
+    if not isinstance(description_raw, str):
+        return jsonify({"error": "description must be a string"}), 400
+    description_value = description_raw.strip()
+    if description_raw and not description_value:
+        return jsonify({"error": "description must not be blank"}), 400
+else:
+    description_value = task["description"]
+```
+
+Then pass `description_value` (stripped) to the UPDATE instead of `data.get("description", task["description"])`.
 
 ## Test Cases
 
-- `GET /health` returns `Access-Control-Allow-Origin: *` on a normal success response.
-- `GET /tasks` returns the CORS headers on a JSON list response.
-- `POST /tasks` returns the CORS headers on a successful JSON create response.
-- `PATCH /tasks/<id>/toggle` returns the CORS headers on a mutating success response.
-- `GET /tasks/export` returns the CORS headers on the CSV export response.
-- Validation failures such as `POST /tasks` with a missing title still include the CORS headers.
-- Not-found responses such as `GET /tasks/999` still include the CORS headers.
-- `OPTIONS /tasks` succeeds and includes the CORS headers needed for browser preflight.
-- `OPTIONS /tasks/<id>/toggle` succeeds and advertises that `PATCH` is allowed for that endpoint.
-- The advertised allowed methods header includes the API’s supported browser-relevant verbs: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, and `OPTIONS`.
-- The allowed headers response includes `Content-Type` so browser JSON requests can pass preflight.
+### POST /tasks — title sanitization
+
+- `POST /tasks` with `title: "  Buy milk  "` returns 201 and the stored title is `"Buy milk"` (leading and trailing spaces stripped).
+- `POST /tasks` with `title: "\tBuy milk\t"` returns 201 and the stored title is `"Buy milk"` (tabs stripped).
+- `POST /tasks` with `title: "\n  Buy milk  \n"` returns 201 and the stored title is `"Buy milk"` (newlines stripped).
+- `POST /tasks` with `title: "  leading only"` returns 201 and the stored title is `"leading only"`.
+- `POST /tasks` with `title: "trailing only  "` returns 201 and the stored title is `"trailing only"`.
+- `POST /tasks` with `title: "  "` (spaces only) returns 400 with `"title must not be blank"`.
+- `POST /tasks` with `title: "\t\n"` (tabs and newlines only) returns 400 with `"title must not be blank"`.
+- `POST /tasks` with `title: "Buy  milk"` (internal double-space) returns 201 and the stored title is `"Buy  milk"` — internal whitespace is preserved, not collapsed.
+- `POST /tasks` with a padded title: stripped value is returned in the response body, not the original.
+- `POST /tasks` with a padded title: `GET /tasks/:id` on the created task returns the stripped title.
+
+### POST /tasks — title length check after stripping
+
+- `POST /tasks` with `title: "   " + "a"*200` (200 non-whitespace chars with leading spaces) returns 201 — length is checked against the stripped value, so 200 chars is accepted.
+- `POST /tasks` with `title: "a"*201` returns 400 with `"title must not exceed 200 characters"` — stripped value is 201 chars.
+- `POST /tasks` with `title: "  " + "a"*201 + "  "` returns 400 with `"title must not exceed 200 characters"` — stripping does not rescue an oversized core.
+
+### POST /tasks — description sanitization
+
+- `POST /tasks` with `description: "  Pick up 2%  "` returns 201 and the stored description is `"Pick up 2%"`.
+- `POST /tasks` with `description: "\t notes \t"` returns 201 and the stored description is `"notes"` (tabs stripped).
+- `POST /tasks` with `description: "   "` (spaces only) returns 400 with `"description must not be blank"`.
+- `POST /tasks` with `description: "\t"` (tab only) returns 400 with `"description must not be blank"`.
+- `POST /tasks` with `description: "\n"` (newline only) returns 400 with `"description must not be blank"`.
+- `POST /tasks` with `description: ""` (empty string) returns 201 and the stored description is `""` — explicitly empty is accepted.
+- `POST /tasks` without a `description` key returns 201 and the stored description is `""` — default is unchanged.
+- `POST /tasks` with `description: "line1  line2"` (internal spaces) returns 201 and the stored description is `"line1  line2"` — internal whitespace is preserved.
+- `POST /tasks` with a padded description: stripped value is returned in the response body.
+
+### POST /tasks — description type validation
+
+- `POST /tasks` with `description: 42` (integer) returns 400 with `"description must be a string"`.
+- `POST /tasks` with `description: true` (boolean) returns 400 with `"description must be a string"`.
+- `POST /tasks` with `description: ["a"]` (array) returns 400 with `"description must be a string"`.
+- `POST /tasks` with `description: null` returns 400 with `"description must be a string"` — `null` is not a valid description value (unlike `notes`, which explicitly allows null).
+
+### POST /tasks — both fields sanitized together
+
+- `POST /tasks` with `title: "  Groceries  "` and `description: "  Needs milk  "` returns 201 with both stripped: title `"Groceries"`, description `"Needs milk"`.
+
+### PUT /tasks/:id — title sanitization
+
+- `PUT /tasks/:id` with `title: "  Updated  "` returns 200 and the stored title is `"Updated"`.
+- `PUT /tasks/:id` with `title: "\tUpdated\t"` returns 200 and the stored title is `"Updated"` (tabs stripped).
+- `PUT /tasks/:id` with `title: "  "` (spaces only) returns 400 with `"title must not be blank"`.
+- `PUT /tasks/:id` with `title: "\t\n"` returns 400 with `"title must not be blank"`.
+- `PUT /tasks/:id` omitting `title` preserves the existing title unchanged (no stripping applied to the persisted value).
+
+### PUT /tasks/:id — title length check after stripping
+
+- `PUT /tasks/:id` with `title: "   " + "a"*200` returns 200 — stripped value is 200 chars, within limit.
+- `PUT /tasks/:id` with `title: "a"*201` returns 400 with `"title must not exceed 200 characters"`.
+
+### PUT /tasks/:id — description sanitization
+
+- `PUT /tasks/:id` with `description: "  New desc  "` returns 200 and the stored description is `"New desc"`.
+- `PUT /tasks/:id` with `description: "\tnotes\n"` returns 200 and the stored description is `"notes"`.
+- `PUT /tasks/:id` with `description: "   "` returns 400 with `"description must not be blank"`.
+- `PUT /tasks/:id` with `description: ""` returns 200 and the stored description is `""` — explicitly clearing description to empty is accepted.
+- `PUT /tasks/:id` omitting `description` preserves the existing description value unchanged.
+- `PUT /tasks/:id` with `description: "inner  spaces"` returns 200 and stores `"inner  spaces"` — internal whitespace preserved.
+
+### PUT /tasks/:id — description type validation
+
+- `PUT /tasks/:id` with `description: 42` returns 400 with `"description must be a string"`.
+- `PUT /tasks/:id` with `description: false` (boolean) returns 400 with `"description must be a string"`.
+- `PUT /tasks/:id` with `description: null` returns 400 with `"description must be a string"`.
+
+### PUT /tasks/:id — both fields sanitized together
+
+- `PUT /tasks/:id` with `title: "  Renamed  "` and `description: "  New body  "` returns 200 with both stripped: title `"Renamed"`, description `"New body"`.
+
+### Round-trip and list verification
+
+- `POST /tasks` with padded title, then `GET /tasks` returns the task with the stripped title in the `items` array.
+- `POST /tasks` with padded title, then `GET /tasks/:id` returns the stripped title in the response.
+- `POST /tasks` with padded title and description, then `GET /tasks/export` returns stripped values in the CSV row.
+- `POST /tasks` with padded title, then `PUT /tasks/:id` omitting title: subsequent `GET` still returns the stripped title from the original create (not re-padded).
 
 Test files added or updated: `tests/test_app.py`
 
 ## Risks / Open Questions
 
-- The issue text does not specify whether CORS should be open to every origin or restricted to a configured allowlist. This spec assumes permissive `*` access because the app is a small demo API and there is no existing configuration mechanism for origin allowlists.
-- `Access-Control-Allow-Headers` could be expanded later if browser clients need custom headers such as `Authorization` or `X-Request-ID`. This spec only includes `Content-Type`, which is the current minimum needed for JSON requests.
-- If a future requirement adds credentialed browser requests, `Access-Control-Allow-Origin: *` will not be sufficient because wildcard origins cannot be combined with credentialed CORS.
+- The existing `test_create_task` test sends `description: "2% please"` and does not assert a stored value, so it will remain unaffected. However, if any test sends a title with surrounding whitespace and asserts the exact unstripped value back, it would break — a review of the test file shows no such test exists.
+- The description field currently has no type validation. Adding it could technically break a caller passing a non-string, but such a caller is already storing bad data.
 
 ## Out of Scope
 
-- Adding authentication, cookies, or any credentialed cross-origin flow. The issue is limited to making the existing unauthenticated API callable from browsers.
-- Introducing new application behavior beyond CORS support, such as changing task CRUD semantics or response payload shapes.
+- Sanitizing other fields (`notes`, `priority`, `due_date`). The issue text targets only `title` and `description`.
+- Adding a maximum-length constraint to `description` (not mentioned in the issue).
+- Normalizing internal whitespace (e.g., collapsing multiple spaces between words). Only leading/trailing stripping is asked for.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -289,6 +289,331 @@ def test_update_task_title_too_long(client):
     assert r.status_code == 400
     assert r.get_json()["error"] == "title must not exceed 200 characters"
 
+
+# --- Input sanitization tests ---
+
+# POST title stripping
+
+def test_create_task_title_strips_spaces(client):
+    r = client.post("/tasks", json={"title": "  Buy milk  "})
+    assert r.status_code == 201
+    assert r.get_json()["title"] == "Buy milk"
+
+
+def test_create_task_title_strips_tabs(client):
+    r = client.post("/tasks", json={"title": "\tBuy milk\t"})
+    assert r.status_code == 201
+    assert r.get_json()["title"] == "Buy milk"
+
+
+def test_create_task_title_strips_newlines(client):
+    r = client.post("/tasks", json={"title": "\n  Buy milk  \n"})
+    assert r.status_code == 201
+    assert r.get_json()["title"] == "Buy milk"
+
+
+def test_create_task_title_strips_leading_only(client):
+    r = client.post("/tasks", json={"title": "  leading only"})
+    assert r.status_code == 201
+    assert r.get_json()["title"] == "leading only"
+
+
+def test_create_task_title_strips_trailing_only(client):
+    r = client.post("/tasks", json={"title": "trailing only  "})
+    assert r.status_code == 201
+    assert r.get_json()["title"] == "trailing only"
+
+
+def test_create_task_title_tabs_and_newlines_only_rejected(client):
+    r = client.post("/tasks", json={"title": "\t\n"})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "title must not be blank"
+
+
+def test_create_task_title_preserves_internal_whitespace(client):
+    r = client.post("/tasks", json={"title": "Buy  milk"})
+    assert r.status_code == 201
+    assert r.get_json()["title"] == "Buy  milk"
+
+
+def test_create_task_stripped_title_in_response(client):
+    r = client.post("/tasks", json={"title": "  Groceries  "})
+    assert r.status_code == 201
+    assert r.get_json()["title"] == "Groceries"
+
+
+def test_create_task_stripped_title_on_get(client):
+    client.post("/tasks", json={"title": "  Groceries  "})
+    r = client.get("/tasks/1")
+    assert r.status_code == 200
+    assert r.get_json()["title"] == "Groceries"
+
+
+# POST title length check after stripping
+
+def test_create_task_title_stripped_to_200_accepted(client):
+    padded = "   " + "a" * 200
+    r = client.post("/tasks", json={"title": padded})
+    assert r.status_code == 201
+    assert r.get_json()["title"] == "a" * 200
+
+
+def test_create_task_title_stripped_to_201_rejected(client):
+    r = client.post("/tasks", json={"title": "a" * 201})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "title must not exceed 200 characters"
+
+
+def test_create_task_title_padded_around_201_core_rejected(client):
+    r = client.post("/tasks", json={"title": "  " + "a" * 201 + "  "})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "title must not exceed 200 characters"
+
+
+# POST description stripping
+
+def test_create_task_description_strips_spaces(client):
+    r = client.post("/tasks", json={"title": "T", "description": "  Pick up 2%  "})
+    assert r.status_code == 201
+    assert r.get_json()["description"] == "Pick up 2%"
+
+
+def test_create_task_description_strips_tabs(client):
+    r = client.post("/tasks", json={"title": "T", "description": "\t notes \t"})
+    assert r.status_code == 201
+    assert r.get_json()["description"] == "notes"
+
+
+def test_create_task_description_spaces_only_rejected(client):
+    r = client.post("/tasks", json={"title": "T", "description": "   "})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "description must not be blank"
+
+
+def test_create_task_description_tab_only_rejected(client):
+    r = client.post("/tasks", json={"title": "T", "description": "\t"})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "description must not be blank"
+
+
+def test_create_task_description_newline_only_rejected(client):
+    r = client.post("/tasks", json={"title": "T", "description": "\n"})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "description must not be blank"
+
+
+def test_create_task_description_empty_string_accepted(client):
+    r = client.post("/tasks", json={"title": "T", "description": ""})
+    assert r.status_code == 201
+    assert r.get_json()["description"] == ""
+
+
+def test_create_task_description_absent_defaults_to_empty(client):
+    r = client.post("/tasks", json={"title": "T"})
+    assert r.status_code == 201
+    assert r.get_json()["description"] == ""
+
+
+def test_create_task_description_preserves_internal_whitespace(client):
+    r = client.post("/tasks", json={"title": "T", "description": "line1  line2"})
+    assert r.status_code == 201
+    assert r.get_json()["description"] == "line1  line2"
+
+
+def test_create_task_stripped_description_in_response(client):
+    r = client.post("/tasks", json={"title": "T", "description": "  Needs milk  "})
+    assert r.status_code == 201
+    assert r.get_json()["description"] == "Needs milk"
+
+
+# POST description type validation
+
+def test_create_task_description_integer_rejected(client):
+    r = client.post("/tasks", json={"title": "T", "description": 42})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "description must be a string"
+
+
+def test_create_task_description_boolean_rejected(client):
+    r = client.post("/tasks", json={"title": "T", "description": True})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "description must be a string"
+
+
+def test_create_task_description_array_rejected(client):
+    r = client.post("/tasks", json={"title": "T", "description": ["a"]})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "description must be a string"
+
+
+def test_create_task_description_null_rejected(client):
+    r = client.post("/tasks", json={"title": "T", "description": None})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "description must be a string"
+
+
+# POST both fields sanitized together
+
+def test_create_task_both_fields_stripped(client):
+    r = client.post("/tasks", json={"title": "  Groceries  ", "description": "  Needs milk  "})
+    assert r.status_code == 201
+    data = r.get_json()
+    assert data["title"] == "Groceries"
+    assert data["description"] == "Needs milk"
+
+
+# PUT title stripping
+
+def test_update_task_title_strips_spaces(client):
+    client.post("/tasks", json={"title": "Original"})
+    r = client.put("/tasks/1", json={"title": "  Updated  "})
+    assert r.status_code == 200
+    assert r.get_json()["title"] == "Updated"
+
+
+def test_update_task_title_strips_tabs(client):
+    client.post("/tasks", json={"title": "Original"})
+    r = client.put("/tasks/1", json={"title": "\tUpdated\t"})
+    assert r.status_code == 200
+    assert r.get_json()["title"] == "Updated"
+
+
+def test_update_task_title_tabs_and_newlines_only_rejected(client):
+    client.post("/tasks", json={"title": "Original"})
+    r = client.put("/tasks/1", json={"title": "\t\n"})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "title must not be blank"
+
+
+def test_update_task_omitting_title_preserves_existing(client):
+    client.post("/tasks", json={"title": "  Keep me  "})
+    r = client.put("/tasks/1", json={"completed": True})
+    assert r.status_code == 200
+    assert r.get_json()["title"] == "Keep me"
+
+
+# PUT title length after stripping
+
+def test_update_task_title_stripped_to_200_accepted(client):
+    client.post("/tasks", json={"title": "Original"})
+    padded = "   " + "a" * 200
+    r = client.put("/tasks/1", json={"title": padded})
+    assert r.status_code == 200
+    assert r.get_json()["title"] == "a" * 200
+
+
+def test_update_task_title_stripped_to_201_rejected(client):
+    client.post("/tasks", json={"title": "Original"})
+    r = client.put("/tasks/1", json={"title": "a" * 201})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "title must not exceed 200 characters"
+
+
+# PUT description stripping
+
+def test_update_task_description_strips_spaces(client):
+    client.post("/tasks", json={"title": "T"})
+    r = client.put("/tasks/1", json={"description": "  New desc  "})
+    assert r.status_code == 200
+    assert r.get_json()["description"] == "New desc"
+
+
+def test_update_task_description_strips_tabs_and_newlines(client):
+    client.post("/tasks", json={"title": "T"})
+    r = client.put("/tasks/1", json={"description": "\tnotes\n"})
+    assert r.status_code == 200
+    assert r.get_json()["description"] == "notes"
+
+
+def test_update_task_description_spaces_only_rejected(client):
+    client.post("/tasks", json={"title": "T"})
+    r = client.put("/tasks/1", json={"description": "   "})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "description must not be blank"
+
+
+def test_update_task_description_empty_string_accepted(client):
+    client.post("/tasks", json={"title": "T", "description": "has content"})
+    r = client.put("/tasks/1", json={"description": ""})
+    assert r.status_code == 200
+    assert r.get_json()["description"] == ""
+
+
+def test_update_task_omitting_description_preserves_existing(client):
+    client.post("/tasks", json={"title": "T", "description": "keep me"})
+    r = client.put("/tasks/1", json={"title": "Updated"})
+    assert r.status_code == 200
+    assert r.get_json()["description"] == "keep me"
+
+
+def test_update_task_description_preserves_internal_whitespace(client):
+    client.post("/tasks", json={"title": "T"})
+    r = client.put("/tasks/1", json={"description": "inner  spaces"})
+    assert r.status_code == 200
+    assert r.get_json()["description"] == "inner  spaces"
+
+
+# PUT description type validation
+
+def test_update_task_description_integer_rejected(client):
+    client.post("/tasks", json={"title": "T"})
+    r = client.put("/tasks/1", json={"description": 42})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "description must be a string"
+
+
+def test_update_task_description_boolean_rejected(client):
+    client.post("/tasks", json={"title": "T"})
+    r = client.put("/tasks/1", json={"description": False})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "description must be a string"
+
+
+def test_update_task_description_null_rejected(client):
+    client.post("/tasks", json={"title": "T"})
+    r = client.put("/tasks/1", json={"description": None})
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "description must be a string"
+
+
+# PUT both fields sanitized together
+
+def test_update_task_both_fields_stripped(client):
+    client.post("/tasks", json={"title": "Original"})
+    r = client.put("/tasks/1", json={"title": "  Renamed  ", "description": "  New body  "})
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["title"] == "Renamed"
+    assert data["description"] == "New body"
+
+
+# Round-trip and list verification
+
+def test_create_task_stripped_title_appears_in_list(client):
+    client.post("/tasks", json={"title": "  Listed  "})
+    r = client.get("/tasks")
+    assert r.status_code == 200
+    assert r.get_json()["items"][0]["title"] == "Listed"
+
+
+def test_create_task_stripped_title_appears_in_export(client):
+    import csv, io
+    client.post("/tasks", json={"title": "  Exported  ", "description": "  desc  "})
+    r = client.get("/tasks/export")
+    assert r.status_code == 200
+    rows = list(csv.DictReader(io.StringIO(r.data.decode())))
+    assert rows[0]["title"] == "Exported"
+    assert rows[0]["description"] == "desc"
+
+
+def test_create_then_update_preserves_stripped_title(client):
+    client.post("/tasks", json={"title": "  Original  "})
+    client.put("/tasks/1", json={"completed": True})
+    r = client.get("/tasks/1")
+    assert r.status_code == 200
+    assert r.get_json()["title"] == "Original"
+
+
 def test_stats_empty(client):
     r = client.get("/tasks/stats")
     assert r.status_code == 200


### PR DESCRIPTION
## Summary

- Strip leading/trailing whitespace from `title` and `description` before storing on `POST /tasks` and `PUT /tasks/:id`
- Reject all-whitespace `description` values with HTTP 400 `"description must not be blank"`
- Add type validation for `description` — non-string values (integer, boolean, array, null) return HTTP 400 `"description must be a string"`
- Title length check now runs against the stripped value, so padding around a ≤200-char core is accepted

## Test plan

- [ ] All 187 tests pass (`python3 -m pytest tests/test_app.py -q`)
- [ ] `POST /tasks` with padded title stores stripped value
- [ ] `POST /tasks` with tab/newline-only title returns 400
- [ ] `POST /tasks` with all-whitespace description returns 400
- [ ] `POST /tasks` with non-string description returns 400
- [ ] `PUT /tasks/:id` with padded title/description stores stripped values
- [ ] `PUT /tasks/:id` omitting description preserves existing value

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)