### PR TITLE
feat: add uptime to GET /health endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ from flask import Flask, request, jsonify, g, Response
 
 app = Flask(__name__)
 
+_start_time = time.monotonic()
 _rate_limit_store: dict[str, list[float]] = {}
 _rate_limit_lock = threading.Lock()
 
@@ -369,7 +370,7 @@ def health_check():
     error = _validate_query_params(frozenset())
     if error:
         return error
-    return jsonify({"status": "ok"})
+    return jsonify({"status": "ok", "uptime_seconds": int(time.monotonic() - _start_time)})
 
 
 @app.route("/tasks", methods=["GET"])

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -21,7 +21,24 @@ def client():
 def test_health_check(client):
     r = client.get("/health")
     assert r.status_code == 200
-    assert r.get_json() == {"status": "ok"}
+    data = r.get_json()
+    assert data["status"] == "ok"
+    assert isinstance(data["uptime_seconds"], int)
+    assert data["uptime_seconds"] >= 0
+
+
+def test_health_check_uptime_increases(client):
+    import time
+    r1 = client.get("/health")
+    time.sleep(0.01)
+    r2 = client.get("/health")
+    assert r2.get_json()["uptime_seconds"] >= r1.get_json()["uptime_seconds"]
+
+
+def test_health_check_response_has_only_expected_keys(client):
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert set(r.get_json().keys()) == {"status", "uptime_seconds"}
 
 
 def test_list_empty(client):


### PR DESCRIPTION
Closes #66

## Summary

- Added `_start_time = time.monotonic()` at module level to track when the app process started
- Updated `GET /health` to return `{"status": "ok", "uptime_seconds": N}` so callers can observe service uptime
- Updated `test_health_check` and added two new tests covering uptime type, monotonic increase, and response shape

## Test plan

### Automated

Command: `python3 -m pytest tests/ -v`

Result: **PASS** — 189/189 tests passed (0 failures)

### Manual

- **Restart behavior**: uptime resets to 0 on process restart — automated tests use `time.monotonic()` within the same process, so they cannot verify reset-on-restart without an actual server restart and a second HTTP request from an external client.
- **Long-running uptime accuracy**: verifying that `uptime_seconds` remains accurate after hours/days of server uptime requires a real server environment running over time, which is outside the scope of unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)