### PR TITLE
feat: add structured JSON logging to API (#67)

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,9 @@ import base64
 import csv
 import io
 import json
+import logging
 import sqlite3
+import sys
 import threading
 import time
 import uuid
@@ -10,6 +12,41 @@ from datetime import datetime
 from flask import Flask, request, jsonify, g, Response
 
 app = Flask(__name__)
+
+
+class _JsonFormatter(logging.Formatter):
+    _SKIP = frozenset({
+        "args", "created", "exc_info", "exc_text", "filename", "funcName",
+        "levelname", "levelno", "lineno", "message", "module", "msecs",
+        "msg", "name", "pathname", "process", "processName", "relativeCreated",
+        "stack_info", "taskName", "thread", "threadName",
+    })
+
+    def format(self, record):
+        record.message = record.getMessage()
+        data = {
+            "timestamp": self.formatTime(record, "%Y-%m-%dT%H:%M:%S"),
+            "level": record.levelname,
+            "message": record.message,
+        }
+        for key, value in record.__dict__.items():
+            if key not in self._SKIP and not key.startswith("_"):
+                data[key] = value
+        return json.dumps(data, default=str)
+
+
+def _setup_logging():
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(_JsonFormatter())
+    _logger = logging.getLogger("api")
+    _logger.setLevel(logging.INFO)
+    if not _logger.handlers:
+        _logger.addHandler(handler)
+    _logger.propagate = False
+    return _logger
+
+
+logger = _setup_logging()
 
 _start_time = time.monotonic()
 _rate_limit_store: dict[str, list[float]] = {}
@@ -52,6 +89,11 @@ def _enforce_rate_limit():
             g._rl_limit = limit
             g._rl_remaining = 0
             g._rl_reset = reset_at
+            logger.warning("rate limit exceeded", extra={
+                "request_id": g.get("_request_id", ""),
+                "client": client_key,
+                "limit": limit,
+            })
             resp = jsonify({"error": "rate limit exceeded"})
             resp.status_code = 429
             resp.headers["Retry-After"] = str(retry_after)
@@ -77,6 +119,14 @@ def _add_response_time_header(response):
         response.headers["X-RateLimit-Limit"] = str(g._rl_limit)
         response.headers["X-RateLimit-Remaining"] = str(g._rl_remaining)
         response.headers["X-RateLimit-Reset"] = str(g._rl_reset)
+    logger.info("request", extra={
+        "request_id": g.get("_request_id", ""),
+        "method": request.method,
+        "path": request.path,
+        "status": response.status_code,
+        "response_time_ms": elapsed_ms,
+        "remote_addr": request.remote_addr,
+    })
     return response
 app.config["DATABASE"] = "tasks.db"
 app.config["LIST_PAGE_SIZE_DEFAULT"] = LIST_PAGE_SIZE_DEFAULT
@@ -553,6 +603,7 @@ def get_task(task_id):
         return error
     row = get_db().execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
     if not row:
+        logger.warning("task not found", extra={"request_id": g.get("_request_id", ""), "task_id": task_id})
         return jsonify({"error": "Task not found"}), 404
     return jsonify(_row(row))
 
@@ -604,6 +655,11 @@ def create_task():
     )
     db.commit()
     row = db.execute("SELECT * FROM tasks WHERE id = ?", (cur.lastrowid,)).fetchone()
+    logger.info("task created", extra={
+        "request_id": g.get("_request_id", ""),
+        "task_id": row["id"],
+        "priority": row["priority"],
+    })
     return jsonify(_row(row)), 201
 
 
@@ -612,6 +668,7 @@ def update_task(task_id):
     db = get_db()
     row = db.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
     if not row:
+        logger.warning("task not found", extra={"request_id": g.get("_request_id", ""), "task_id": task_id})
         return jsonify({"error": "Task not found"}), 404
     data = request.get_json(silent=True)
     if data is None and request.is_json and request.get_data():
@@ -679,6 +736,7 @@ def update_task(task_id):
     )
     db.commit()
     row = db.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
+    logger.info("task updated", extra={"request_id": g.get("_request_id", ""), "task_id": task_id})
     return jsonify(_row(row))
 
 
@@ -687,6 +745,7 @@ def delete_completed_tasks():
     db = get_db()
     cur = db.execute("DELETE FROM tasks WHERE completed = 1")
     db.commit()
+    logger.info("completed tasks deleted", extra={"request_id": g.get("_request_id", ""), "deleted": cur.rowcount})
     return jsonify({"deleted": cur.rowcount})
 
 
@@ -695,9 +754,11 @@ def delete_task(task_id):
     db = get_db()
     row = db.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
     if not row:
+        logger.warning("task not found", extra={"request_id": g.get("_request_id", ""), "task_id": task_id})
         return jsonify({"error": "Task not found"}), 404
     db.execute("DELETE FROM tasks WHERE id = ?", (task_id,))
     db.commit()
+    logger.info("task deleted", extra={"request_id": g.get("_request_id", ""), "task_id": task_id})
     return jsonify({"message": "Task deleted"})
 
 
@@ -707,6 +768,7 @@ def toggle_task(task_id):
     db = get_db()
     row = db.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
     if not row:
+        logger.warning("task not found", extra={"request_id": g.get("_request_id", ""), "task_id": task_id})
         return jsonify({"error": "Task not found"}), 404
     new_completed = not bool(row["completed"])
     db.execute(
@@ -714,6 +776,11 @@ def toggle_task(task_id):
     )
     db.commit()
     row = db.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
+    logger.info("task toggled", extra={
+        "request_id": g.get("_request_id", ""),
+        "task_id": task_id,
+        "completed": new_completed,
+    })
     return jsonify(_row(row))
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,7 @@
+import json
+import logging
 import pytest
-from app import app, get_db, _rate_limit_store
+from app import app, get_db, _rate_limit_store, logger as api_logger
 
 
 @pytest.fixture(autouse=True)
@@ -1692,3 +1694,133 @@ def test_export_includes_urgent_column(client):
     rows = list(reader)
     assert rows[0]["urgent"] == "true"
     assert rows[1]["urgent"] == "false"
+
+
+# --- Structured logging tests ---
+
+class _CaptureHandler(logging.Handler):
+    def __init__(self):
+        super().__init__(logging.DEBUG)
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+@pytest.fixture
+def captured_logs():
+    """Attach a handler directly to the api logger and yield parsed JSON log dicts."""
+    from app import _JsonFormatter
+    handler = _CaptureHandler()
+    api_logger.addHandler(handler)
+    fmt = _JsonFormatter()
+
+    yield lambda: [json.loads(fmt.format(r)) for r in handler.records]
+
+    api_logger.removeHandler(handler)
+
+
+def test_request_log_is_valid_json(client, captured_logs):
+    client.get("/health")
+    logs = captured_logs()
+    request_logs = [l for l in logs if l.get("message") == "request"]
+    assert len(request_logs) == 1
+
+
+def test_request_log_contains_expected_fields(client, captured_logs):
+    client.get("/health")
+    logs = captured_logs()
+    req = next(l for l in logs if l.get("message") == "request")
+    assert req["method"] == "GET"
+    assert req["path"] == "/health"
+    assert req["status"] == 200
+    assert isinstance(req["response_time_ms"], int)
+    assert "request_id" in req
+    assert "timestamp" in req
+    assert req["level"] == "INFO"
+
+
+def test_request_log_includes_request_id_matching_header(client, captured_logs):
+    r = client.get("/health")
+    header_id = r.headers.get("X-Request-ID")
+    logs = captured_logs()
+    req = next(l for l in logs if l.get("message") == "request")
+    assert req["request_id"] == header_id
+
+
+def test_task_created_log_emitted(client, captured_logs):
+    client.post("/tasks", json={"title": "Log me", "priority": "high"})
+    logs = captured_logs()
+    created = [l for l in logs if l.get("message") == "task created"]
+    assert len(created) == 1
+    assert created[0]["task_id"] == 1
+    assert created[0]["priority"] == "high"
+
+
+def test_task_updated_log_emitted(client, captured_logs):
+    client.post("/tasks", json={"title": "Original"})
+    client.put("/tasks/1", json={"title": "Updated"})
+    logs = captured_logs()
+    updated = [l for l in logs if l.get("message") == "task updated"]
+    assert len(updated) == 1
+    assert updated[0]["task_id"] == 1
+
+
+def test_task_deleted_log_emitted(client, captured_logs):
+    client.post("/tasks", json={"title": "Delete me"})
+    client.delete("/tasks/1")
+    logs = captured_logs()
+    deleted = [l for l in logs if l.get("message") == "task deleted"]
+    assert len(deleted) == 1
+    assert deleted[0]["task_id"] == 1
+
+
+def test_task_toggled_log_emitted(client, captured_logs):
+    client.post("/tasks", json={"title": "Toggle me"})
+    client.patch("/tasks/1/toggle")
+    logs = captured_logs()
+    toggled = [l for l in logs if l.get("message") == "task toggled"]
+    assert len(toggled) == 1
+    assert toggled[0]["task_id"] == 1
+    assert toggled[0]["completed"] is True
+
+
+def test_task_not_found_log_is_warning(client, captured_logs):
+    client.get("/tasks/999")
+    logs = captured_logs()
+    warnings = [l for l in logs if l.get("message") == "task not found"]
+    assert len(warnings) == 1
+    assert warnings[0]["level"] == "WARNING"
+    assert warnings[0]["task_id"] == 999
+
+
+def test_completed_tasks_deleted_log_emitted(client, captured_logs):
+    client.post("/tasks", json={"title": "Done"})
+    client.patch("/tasks/1/toggle")
+    client.delete("/tasks/completed")
+    logs = captured_logs()
+    batch = [l for l in logs if l.get("message") == "completed tasks deleted"]
+    assert len(batch) == 1
+    assert batch[0]["deleted"] == 1
+
+
+def test_log_timestamp_format(client, captured_logs):
+    client.get("/health")
+    logs = captured_logs()
+    req = next(l for l in logs if l.get("message") == "request")
+    from datetime import datetime
+    datetime.strptime(req["timestamp"], "%Y-%m-%dT%H:%M:%S")
+
+
+def test_rate_limit_exceeded_log_is_warning(client, captured_logs):
+    app.config["RATE_LIMIT_ENABLED"] = True
+    app.config["RATE_LIMIT_REQUESTS"] = 1
+    app.config["RATE_LIMIT_WINDOW"] = 60
+    client.get("/health")  # consume the one allowed request
+    client.get("/health")  # this one should be rate-limited
+    app.config["RATE_LIMIT_ENABLED"] = False
+    logs = captured_logs()
+    rl_logs = [l for l in logs if l.get("message") == "rate limit exceeded"]
+    assert len(rl_logs) == 1
+    assert rl_logs[0]["level"] == "WARNING"
+    assert rl_logs[0]["limit"] == 1


### PR DESCRIPTION
## Summary

- Adds a `_JsonFormatter` class and a module-level `logger` (Python `logging`, no new dependencies) that emits one JSON object per line to stdout
- Every HTTP response triggers an INFO log with `method`, `path`, `status`, `response_time_ms`, `request_id`, and `remote_addr`
- CRUD mutations (`create_task`, `update_task`, `delete_task`, `toggle_task`, `delete_completed_tasks`) emit INFO events with `task_id` and relevant context
- Not-found paths and rate-limit breaches emit WARNING-level events

## Test plan

### Automated

Command: `pytest tests/ -v`

Result: **219 passed** in 0.56s

11 new tests cover:
- Request log is valid JSON
- Request log contains expected fields (method, path, status, response_time_ms, request_id, level, timestamp)
- `request_id` in log matches `X-Request-ID` response header
- Task created / updated / deleted / toggled events are logged with correct fields
- 404 paths log at WARNING with task_id
- Bulk-delete logs count of deleted rows
- Timestamp is parseable as `%Y-%m-%dT%H:%M:%S`
- Rate-limit exceeded logs at WARNING with `limit` field

### Manual

- **Log format in a running server** — `python app.py` then `curl localhost:5000/tasks` and verify stdout shows one JSON object per line with expected keys. Cannot automate because `pytest` uses Flask's test client which doesn't exercise the real stdout stream in the same way.
- **Log output stays readable under load** — rapid concurrent requests should each produce distinct `request_id` values with no interleaving of partial lines. Requires a live server and a concurrency tool (e.g. `ab` or `wrk`); not feasible in unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #67