### PR TITLE
Add structured logging to API

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import base64
 import csv
 import io
 import json
+import logging
 import sqlite3
 import threading
 import time
@@ -10,6 +11,34 @@ from datetime import datetime
 from flask import Flask, request, jsonify, g, Response
 
 app = Flask(__name__)
+
+# Structured Logging Configuration
+class JsonFormatter(logging.Formatter):
+    def format(self, record):
+        log_record = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "event": record.msg if isinstance(record.msg, str) else "log_event",
+        }
+        if isinstance(record.msg, dict):
+            log_record.update(record.msg)
+            log_record["event"] = "request_completed"
+
+        if hasattr(record, "request_id"):
+            log_record["request_id"] = record.request_id
+        
+        if record.exc_info:
+            log_record["exception"] = self.formatException(record.exc_info)
+            
+        return json.dumps(log_record)
+
+handler = logging.StreamHandler()
+handler.setFormatter(JsonFormatter())
+logger = logging.getLogger("app")
+logger.setLevel(logging.INFO)
+logger.addHandler(handler)
+# Disable propagation to avoid duplicate logs if the root logger is also configured
+logger.propagate = False
 
 _start_time = time.monotonic()
 _rate_limit_store: dict[str, list[float]] = {}
@@ -68,8 +97,10 @@ def _enforce_rate_limit():
 def _add_response_time_header(response):
     start = g.get("_request_start", time.monotonic())
     elapsed_ms = round((time.monotonic() - start) * 1000)
+    request_id = g.get("_request_id", "")
+    
     response.headers["X-Response-Time"] = f"{elapsed_ms}ms"
-    response.headers["X-Request-ID"] = g.get("_request_id", "")
+    response.headers["X-Request-ID"] = request_id
     response.headers["Access-Control-Allow-Origin"] = "*"
     response.headers["Access-Control-Allow-Methods"] = "GET, POST, PUT, PATCH, DELETE, OPTIONS"
     response.headers["Access-Control-Allow-Headers"] = "Content-Type"
@@ -77,6 +108,17 @@ def _add_response_time_header(response):
         response.headers["X-RateLimit-Limit"] = str(g._rl_limit)
         response.headers["X-RateLimit-Remaining"] = str(g._rl_remaining)
         response.headers["X-RateLimit-Reset"] = str(g._rl_reset)
+    
+    # Log request completion
+    logger.info({
+        "request_id": request_id,
+        "method": request.method,
+        "path": request.path,
+        "status": response.status_code,
+        "duration_ms": elapsed_ms,
+        "ip": request.remote_addr,
+    })
+    
     return response
 app.config["DATABASE"] = "tasks.db"
 app.config["LIST_PAGE_SIZE_DEFAULT"] = LIST_PAGE_SIZE_DEFAULT
@@ -718,4 +760,5 @@ def toggle_task(task_id):
 
 
 if __name__ == "__main__":
+    logger.info("Starting app on http://localhost:5000")
     app.run(debug=True)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,62 @@
+import json
+import pytest
+import logging
+import io
+from app import app, logger
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as c:
+        yield c
+
+def test_structured_logging_json(client):
+    # Create a buffer to capture logs
+    log_buffer = io.StringIO()
+    handler = logging.StreamHandler(log_buffer)
+    # We use the same formatter as the app to verify it
+    from app import JsonFormatter
+    handler.setFormatter(JsonFormatter())
+    
+    logger.addHandler(handler)
+    try:
+        r = client.get("/health")
+        assert r.status_code == 200
+        
+        # Get the logs from the buffer
+        log_output = log_buffer.getvalue()
+        assert log_output != ""
+        
+        # Parse the JSON log
+        lines = log_output.strip().split("\n")
+        found = False
+        for line in lines:
+            data = json.loads(line)
+            if data.get("event") == "request_completed":
+                assert "timestamp" in data
+                assert "request_id" in data
+                assert data["method"] == "GET"
+                assert data["path"] == "/health"
+                assert data["status"] == 200
+                assert "duration_ms" in data
+                assert "ip" in data
+                found = True
+                break
+        assert found, "Request completed log not found in structured logs"
+    finally:
+        logger.removeHandler(handler)
+
+def test_app_startup_log():
+    # Verify we can log a simple string message too
+    log_buffer = io.StringIO()
+    handler = logging.StreamHandler(log_buffer)
+    from app import JsonFormatter
+    handler.setFormatter(JsonFormatter())
+    logger.addHandler(handler)
+    try:
+        logger.info("Test startup message")
+        data = json.loads(log_buffer.getvalue().strip())
+        assert data["event"] == "Test startup message"
+        assert data["level"] == "INFO"
+    finally:
+        logger.removeHandler(handler)


### PR DESCRIPTION
This PR implements structured logging (JSON format) for the API endpoints.

Changes:
- Added a custom `JsonFormatter` to `app.py` that formats log records as JSON.
- Configured the `app` logger to use this formatter and output to stderr.
- Updated the `after_request` hook to log a structured record for each request containing `request_id`, `method`, `path`, `status`, `duration_ms`, and `ip`.
- Added an app startup log message in JSON format.
- Added `tests/test_logging.py` to verify the structured logging implementation.

## Test plan
### Automated
- Command: `pytest tests/ -v`
- Summary: 210 passed. All existing tests pass, and new tests verify that JSON logs are correctly emitted and contain the expected fields.

### Manual
- **Verify JSON format in production logs**: Manual check to ensure logs are correctly captured by the production logging aggregator (e.g., CloudWatch, ELK) in JSON format.
- **Log rotation and retention**: Verify that the structured logs follow the expected log rotation and retention policies of the deployment environment.

Closes #67