### PR TITLE
Add GET /tasks/recent endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ import sqlite3
 import threading
 import time
 import uuid
-from datetime import datetime
+from datetime import datetime, UTC
 from flask import Flask, request, jsonify, g, Response
 
 app = Flask(__name__)
@@ -152,6 +152,7 @@ def get_db():
             "due_date TEXT, "
             "notes TEXT, "
             "created_at TEXT NOT NULL DEFAULT '', "
+            "updated_at TEXT NOT NULL DEFAULT '', "
             "urgent INTEGER NOT NULL DEFAULT 0, "
             "color TEXT)"
         )
@@ -165,6 +166,12 @@ def get_db():
             db.execute(
                 "UPDATE tasks SET created_at = strftime('%Y-%m-%dT%H:%M:%S', 'now') "
                 "WHERE created_at = ''"
+            )
+        if "updated_at" not in columns:
+            db.execute("ALTER TABLE tasks ADD COLUMN updated_at TEXT NOT NULL DEFAULT ''")
+            db.execute(
+                "UPDATE tasks SET updated_at = created_at "
+                "WHERE updated_at = ''"
             )
         if "urgent" not in columns:
             db.execute("ALTER TABLE tasks ADD COLUMN urgent INTEGER NOT NULL DEFAULT 0")
@@ -193,6 +200,7 @@ def _row(row):
         "due_date": row["due_date"],
         "notes": row["notes"],
         "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
         "urgent": bool(row["urgent"]),
         # Always include color for consistent API shape
         "color": row["color"],
@@ -600,7 +608,7 @@ def export_tasks():
 
     buf = io.StringIO()
     writer = csv.writer(buf)
-    writer.writerow(["id", "title", "description", "completed", "priority", "due_date", "notes", "created_at", "urgent", "assignee"])
+    writer.writerow(["id", "title", "description", "completed", "priority", "due_date", "notes", "created_at", "updated_at", "urgent", "assignee"])
     for row in page["items"]:
         writer.writerow([
             row["id"],
@@ -611,6 +619,7 @@ def export_tasks():
             row["due_date"] if row["due_date"] is not None else "",
             row["notes"] if row["notes"] is not None else "",
             row["created_at"],
+            row["updated_at"],
             str(bool(row["urgent"])).lower(),
             row["assignee"] if row["assignee"] is not None else "",
         ])
@@ -625,6 +634,33 @@ def export_tasks():
             "X-Next-Cursor": page["next_cursor"] or "",
         },
     )
+
+
+@app.route("/tasks/recent", methods=["GET"])
+def get_recent_tasks():
+    error = _validate_query_params(frozenset({"limit"}))
+    if error:
+        return error
+    
+    limit_str = request.args.get("limit", "10")
+    try:
+        limit = int(limit_str)
+    except (TypeError, ValueError):
+        return jsonify({"error": "limit must be a positive integer"}), 400
+    
+    if limit < 1:
+        return jsonify({"error": "limit must be a positive integer"}), 400
+    
+    if limit > 100:
+        return jsonify({"error": "limit must not exceed 100"}), 400
+    
+    db = get_db()
+    rows = db.execute(
+        "SELECT * FROM tasks ORDER BY updated_at DESC, id DESC LIMIT ?",
+        (limit,)
+    ).fetchall()
+    
+    return jsonify({"items": [_row(r) for r in rows]})
 
 
 @app.route("/tasks/<int:task_id>", methods=["GET"])
@@ -687,10 +723,11 @@ def create_task():
         return jsonify({"error": "assignee must be a string or null"}), 400
 
     db = get_db()
+    now = datetime.now(UTC).strftime('%Y-%m-%dT%H:%M:%S.%f')
     cur = db.execute(
-        "INSERT INTO tasks (title, description, completed, priority, due_date, notes, created_at, urgent, color, assignee) "
-        "VALUES (?, ?, 0, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%S', 'now'), ?, ?, ?)",
-        (title, description, priority, due_date, notes, int(urgent), color, assignee),
+        "INSERT INTO tasks (title, description, completed, priority, due_date, notes, created_at, updated_at, urgent, color, assignee) "
+        "VALUES (?, ?, 0, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (title, description, priority, due_date, notes, now, now, int(urgent), color, assignee),
     )
     db.commit()
     row = db.execute("SELECT * FROM tasks WHERE id = ?", (cur.lastrowid,)).fetchone()
@@ -768,8 +805,9 @@ def update_task(task_id):
     else:
         assignee = task.get("assignee")
 
+    now = datetime.now(UTC).strftime('%Y-%m-%dT%H:%M:%S.%f')
     db.execute(
-        "UPDATE tasks SET title = ?, description = ?, completed = ?, priority = ?, due_date = ?, notes = ?, urgent = ?, color = ?, assignee = ? WHERE id = ?",
+        "UPDATE tasks SET title = ?, description = ?, completed = ?, priority = ?, due_date = ?, notes = ?, urgent = ?, color = ?, assignee = ?, updated_at = ? WHERE id = ?",
         (
             data.get("title", task["title"]),
             data.get("description", task["description"]),
@@ -780,6 +818,7 @@ def update_task(task_id):
             int(urgent),
             color,
             assignee,
+            now,
             task_id,
         ),
     )
@@ -815,8 +854,9 @@ def toggle_task(task_id):
     if not row:
         return jsonify({"error": "Task not found"}), 404
     new_completed = not bool(row["completed"])
+    now = datetime.now(UTC).strftime('%Y-%m-%dT%H:%M:%S.%f')
     db.execute(
-        "UPDATE tasks SET completed = ? WHERE id = ?", (int(new_completed), task_id)
+        "UPDATE tasks SET completed = ?, updated_at = ? WHERE id = ?", (int(new_completed), now, task_id)
     )
     db.commit()
     row = db.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -167,6 +167,7 @@ def test_list_tasks_can_filter_by_priority(client):
             "due_date": None,
             "notes": None,
             "created_at": high["created_at"],
+            "updated_at": high["updated_at"],
             "urgent": False,
             "color": None,
             "assignee": None,
@@ -860,7 +861,7 @@ def test_export_empty_returns_header_only(client):
     r = client.get("/tasks/export")
     assert r.status_code == 200
     lines = r.data.decode().splitlines()
-    assert lines == ["id,title,description,completed,priority,due_date,notes,created_at,urgent,assignee"]
+    assert lines == ["id,title,description,completed,priority,due_date,notes,created_at,updated_at,urgent,assignee"]
 
 
 def test_export_includes_all_tasks(client):
@@ -1867,3 +1868,186 @@ def test_pagination_with_color_filter(client):
     data = r.get_json()
     assert len(data["items"]) == 1
     assert data["items"][0]["title"] == "Task 2"
+
+
+def test_get_recent_tasks_empty(client):
+    r = client.get("/tasks/recent")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["items"] == []
+
+
+def test_get_recent_tasks_default_limit(client):
+    for i in range(15):
+        client.post("/tasks", json={"title": f"Task {i}"})
+    
+    r = client.get("/tasks/recent")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert len(data["items"]) == 10
+    # Most recent first (Task 14 is most recent)
+    assert data["items"][0]["title"] == "Task 14"
+    assert data["items"][9]["title"] == "Task 5"
+
+
+def test_get_recent_tasks_custom_limit(client):
+    for i in range(10):
+        client.post("/tasks", json={"title": f"Task {i}"})
+    
+    r = client.get("/tasks/recent?limit=5")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert len(data["items"]) == 5
+    assert data["items"][0]["title"] == "Task 9"
+    assert data["items"][4]["title"] == "Task 5"
+
+
+def test_get_recent_tasks_limit_one(client):
+    client.post("/tasks", json={"title": "Task 1"})
+    client.post("/tasks", json={"title": "Task 2"})
+    
+    r = client.get("/tasks/recent?limit=1")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert len(data["items"]) == 1
+    assert data["items"][0]["title"] == "Task 2"
+
+
+def test_get_recent_tasks_limit_exceeds_count(client):
+    client.post("/tasks", json={"title": "Task 1"})
+    client.post("/tasks", json={"title": "Task 2"})
+    
+    r = client.get("/tasks/recent?limit=10")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert len(data["items"]) == 2
+
+
+def test_get_recent_tasks_invalid_limit_negative(client):
+    r = client.get("/tasks/recent?limit=-1")
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "limit must be a positive integer"
+
+
+def test_get_recent_tasks_invalid_limit_zero(client):
+    r = client.get("/tasks/recent?limit=0")
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "limit must be a positive integer"
+
+
+def test_get_recent_tasks_invalid_limit_string(client):
+    r = client.get("/tasks/recent?limit=abc")
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "limit must be a positive integer"
+
+
+def test_get_recent_tasks_limit_max(client):
+    for i in range(110):
+        client.post("/tasks", json={"title": f"Task {i}"})
+    
+    r = client.get("/tasks/recent?limit=100")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert len(data["items"]) == 100
+
+
+def test_get_recent_tasks_limit_exceeds_max(client):
+    r = client.get("/tasks/recent?limit=101")
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "limit must not exceed 100"
+
+
+def test_get_recent_tasks_orders_by_updated_at(client):
+    import time
+    client.post("/tasks", json={"title": "Task 1"})
+    time.sleep(0.01)
+    client.post("/tasks", json={"title": "Task 2"})
+    time.sleep(0.01)
+    client.post("/tasks", json={"title": "Task 3"})
+    time.sleep(0.01)
+    # Update Task 1 to make it most recent
+    client.put("/tasks/1", json={"title": "Task 1 Updated"})
+    
+    r = client.get("/tasks/recent")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert len(data["items"]) == 3
+    # Task 1 should be first because it was updated most recently
+    assert data["items"][0]["title"] == "Task 1 Updated"
+    assert data["items"][1]["title"] == "Task 3"
+    assert data["items"][2]["title"] == "Task 2"
+
+
+def test_get_recent_tasks_toggle_updates_order(client):
+    import time
+    client.post("/tasks", json={"title": "Task 1"})
+    time.sleep(0.01)
+    client.post("/tasks", json={"title": "Task 2"})
+    time.sleep(0.01)
+    # Toggle Task 1 to update it
+    client.patch("/tasks/1/toggle")
+    
+    r = client.get("/tasks/recent")
+    assert r.status_code == 200
+    data = r.get_json()
+    # Task 1 should be first because it was toggled (updated) most recently
+    assert data["items"][0]["title"] == "Task 1"
+    assert data["items"][1]["title"] == "Task 2"
+
+
+def test_get_recent_tasks_unsupported_query_param(client):
+    r = client.get("/tasks/recent?invalid=value")
+    assert r.status_code == 400
+    assert r.get_json()["error"] == "unsupported query parameter: invalid"
+
+
+def test_get_recent_tasks_includes_all_fields(client):
+    client.post("/tasks", json={
+        "title": "Test Task",
+        "description": "Test Description",
+        "priority": "high",
+        "due_date": "2024-12-31",
+        "notes": "Test Notes",
+        "urgent": True,
+        "color": "red",
+        "assignee": "John"
+    })
+    
+    r = client.get("/tasks/recent")
+    assert r.status_code == 200
+    data = r.get_json()
+    assert len(data["items"]) == 1
+    task = data["items"][0]
+    assert task["title"] == "Test Task"
+    assert task["description"] == "Test Description"
+    assert task["priority"] == "high"
+    assert task["due_date"] == "2024-12-31"
+    assert task["notes"] == "Test Notes"
+    assert task["urgent"] is True
+    assert task["color"] == "red"
+    assert task["assignee"] == "John"
+    assert "created_at" in task
+    assert "updated_at" in task
+
+
+def test_task_includes_updated_at_field(client):
+    r = client.post("/tasks", json={"title": "Task"})
+    assert r.status_code == 201
+    data = r.get_json()
+    assert "updated_at" in data
+    assert data["updated_at"] == data["created_at"]
+
+
+def test_update_task_changes_updated_at(client):
+    import time
+    r1 = client.post("/tasks", json={"title": "Original"})
+    created_at = r1.get_json()["created_at"]
+    updated_at_initial = r1.get_json()["updated_at"]
+    
+    time.sleep(0.01)
+    r2 = client.put("/tasks/1", json={"title": "Updated"})
+    updated_at_after = r2.get_json()["updated_at"]
+    
+    assert updated_at_initial == created_at
+    assert updated_at_after != created_at
+    assert updated_at_after > updated_at_initial


### PR DESCRIPTION
## Summary
- Adds `GET /tasks/recent` endpoint to return the N most recently created or updated tasks
- Adds `updated_at` field to track when tasks are modified
- Updates existing endpoints to maintain the `updated_at` timestamp

## Implementation Details

### New Endpoint: `GET /tasks/recent`
- Returns tasks ordered by most recent creation or update
- Query parameter: `limit` (optional, default: 10, max: 100)
- Response: `{"items": [...]}`
- Validates limit parameter and returns 400 for invalid values

### Schema Changes
- Added `updated_at` TEXT field to tasks table
- `updated_at` is set to current timestamp when:
  - Task is created (`POST /tasks`)
  - Task is updated (`PUT /tasks/:id`)
  - Task completion is toggled (`PATCH /tasks/:id/toggle`)
- For existing tasks, `updated_at` is initialized to `created_at` value
- Timestamp format: ISO 8601 with microsecond precision

### Updated Endpoints
- `POST /tasks` - Sets both `created_at` and `updated_at` to current time
- `PUT /tasks/:id` - Updates `updated_at` to current time
- `PATCH /tasks/:id/toggle` - Updates `updated_at` to current time
- `GET /tasks/export` - Includes `updated_at` in CSV export
- All task responses now include `updated_at` field

## Test Plan

### Automated
**Command:** `pytest tests/ -v`

**Result:** ✅ All 246 tests passed

Added comprehensive test coverage for the new endpoint:
- Empty database returns empty array
- Default limit of 10 tasks
- Custom limit parameter validation
- Limit boundaries (min=1, max=100)
- Invalid limit values (negative, zero, non-numeric, exceeds max)
- Tasks are ordered by `updated_at` DESC (most recent first)
- Updating a task moves it to the top of recent tasks
- Toggling completion updates the order
- All task fields are included in response
- `updated_at` field is present in all task responses
- `updated_at` changes when task is modified

### Manual
- **Database migration compatibility**: Verify that existing databases correctly add the `updated_at` column and initialize values from `created_at`. This requires testing against a production-like database with existing data.
  - *Why manual*: Cannot be fully automated as it requires testing database migration logic with real persistent data across different SQLite versions.

- **Timestamp precision under load**: Verify that the microsecond-precision timestamps maintain proper ordering when multiple tasks are created/updated in rapid succession under high concurrency.
  - *Why manual*: Automated tests cannot reliably simulate true concurrent request handling and race conditions that might occur in production.

- **API documentation accuracy**: Verify the endpoint behavior matches what will be documented (response format, error messages, header presence).
  - *Why manual*: Requires human review of API documentation and actual behavior to ensure they align with user expectations.

Resolves #43